### PR TITLE
Fix a minor typo in the DI documentation

### DIFF
--- a/docs/guides/di-container.md
+++ b/docs/guides/di-container.md
@@ -92,4 +92,4 @@ This is just a simple example, but one that could prove useful when writing test
 
 ## Useful hint
 
-Don't pass to many dependencies in your classes. Having more than three dependencies is usually a sign that your class may be doing too much, and that it should probably be broken down into more different classes.
+Don't pass too many dependencies in your classes. Having more than three dependencies is usually a sign that your class may be doing too much, and that it should probably be broken down into more different classes.


### PR DESCRIPTION
Fixed `to many` -> `too many` typo