### PR TITLE
Add custom badges/shields on doc pages

### DIFF
--- a/docs/advanced/aliases.md
+++ b/docs/advanced/aliases.md
@@ -3,7 +3,7 @@ id: aliases
 title: Helpful aliases
 ---
 
-[![docs-source](https://img.shields.io/badge/source-eigthshift--frontend--libs-yellow?style=for-the-badge&logo=javascript)](https://github.com/infinum/eightshift-frontend-libs/tree/develop/scripts)
+[![docs-source](https://img.shields.io/badge/source-eigthshift--frontend--libs-yellow?style=for-the-badge&logo=javascript&labelColor=2a2a2a)](https://github.com/infinum/eightshift-frontend-libs/tree/develop/scripts)
 
 We have created a lot of helpful aliases that you can use in your project.
 

--- a/docs/advanced/aliases.md
+++ b/docs/advanced/aliases.md
@@ -3,6 +3,8 @@ id: aliases
 title: Helpful aliases
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--frontend--libs-yellow?style=for-the-badge&logo=javascript)](https://github.com/infinum/eightshift-frontend-libs/tree/develop/scripts)
+
 We have created a lot of helpful aliases that you can use in your project.
 
 ## JavaScript Dynamic Import Helper
@@ -77,7 +79,7 @@ import 'EighshiftBlocksBabelPolyfill';
 
 ## Scss EighshiftFrontendLibs
 
-Alias providing [Eighshift Frontend Libs](https://infinum.github.io/eightshift-frontend-libs/sassdocs/). 
+Alias providing [Eighshift Frontend Libs](https://infinum.github.io/eightshift-frontend-libs/sassdocs/).
 
 #### Usage
 

--- a/docs/advanced/components-color-palette.md
+++ b/docs/advanced/components-color-palette.md
@@ -3,6 +3,8 @@ id: components-color-palette
 title: Color Palette
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--frontend--libs-yellow?style=for-the-badge&logo=javascript&labelColor=2a2a2a)](https://github.com/infinum/eightshift-frontend-libs/blob/develop/components/color-palette-custom/color-palette-custom.js)
+
 This is a custom React component that renders a custom color picker exactly the same as the native block editor component, but on the `save` method in the attributes, we save the color name and not the color hex value.
 
 ## Usage

--- a/docs/advanced/components-heading-level.md
+++ b/docs/advanced/components-heading-level.md
@@ -3,6 +3,8 @@ id: components-heading-level
 title: Heading Level
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--frontend--libs-yellow?style=for-the-badge&logo=javascript&labelColor=2a2a2a)](https://github.com/infinum/eightshift-frontend-libs/blob/develop/components/heading-level/heading-level.js)
+
 This is a custom React component that renders a custom heading level (`<h1>` to `<h6>`). It is used in the heading component or block.
 
 ## Usage

--- a/docs/advanced/helpers-components.md
+++ b/docs/advanced/helpers-components.md
@@ -3,6 +3,8 @@ id: helpers-components-helpers
 title: Components
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--libs-blue?style=for-the-badge&logo=php&labelColor=2a2a2a)](https://github.com/infinum/eightshift-libs/blob/develop/src/helpers/class-components.php)
+
 Components helper is located in `Eightshift Libs`. To extend it, use `Eightshift_Libs\Helpers\Components` class.
 
 We have created this simple helper that you can use in any PHP class as a static helper. To see all of the components helpers go [here](https://github.com/infinum/eightshift-libs/blob/develop/src/helpers/class-components.php).

--- a/docs/advanced/helpers-error-logger.md
+++ b/docs/advanced/helpers-error-logger.md
@@ -3,6 +3,8 @@ id: helpers-error-logger-helpers
 title: Error Logger
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--libs-blue?style=for-the-badge&logo=php&labelColor=2a2a2a)](https://github.com/infinum/eightshift-libs/blob/develop/src/helpers/trait-error-logger.php)
+
 Object trait is located in `Eightshift Libs`. To extend it, use `Eightshift_Libs\Helpers\Error_Logger` class.
 
 If you are working with Ajax or REST API in your project, this logger will come in handy. We have created this simple trait helper that you can use in any PHP class as a [trait](/eightshift-docs/docs/guides/extending-classes). To see all of the class helper go [here](https://github.com/infinum/eightshift-libs/blob/develop/src/helpers/trait-error-logger.php).

--- a/docs/advanced/helpers-object.md
+++ b/docs/advanced/helpers-object.md
@@ -3,6 +3,8 @@ id: helpers-object-helpers
 title: Object
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--libs-blue?style=for-the-badge&logo=php&labelColor=2a2a2a)](https://github.com/infinum/eightshift-libs/blob/develop/src/helpers/class-object-helper.php)
+
 Object trait is located in `Eightshift Libs`. To extend it, use `Eightshift_Libs\Helpers\Object_Helper` class.
 
 All of us have some custom helpers and stuff that we use around on multiple the project. We have created this simple trait helper that you can use in any PHP class as a [trait](/eightshift-docs/docs/guides/extending-classes). To see all of the class helper go [here](https://github.com/infinum/eightshift-libs/blob/develop/src/helpers/class-object-helper.php).

--- a/docs/advanced/helpers-shortcode.md
+++ b/docs/advanced/helpers-shortcode.md
@@ -3,5 +3,8 @@ id: helpers-shortcode-helpers
 title: Shortcode
 ---
 
-Login class is located in `Eightshift Libs`. To extend it use `Eightshift_Libs\Helpers\Shortcode` class.
+[![docs-source](https://img.shields.io/badge/source-eigthshift--libs-blue?style=for-the-badge&logo=php&labelColor=2a2a2a)](https://github.com/infinum/eightshift-libs/blob/develop/src/helpers/class-shortcode.php)
 
+Shortcode class is located in `Eightshift Libs`. To extend it use `Eightshift_Libs\Helpers\Shortcode` class.
+
+This class has a method `get_shortcode` that allows programaticall output of specific shortcode. It is more optimized implemetation of `do_shortcode` function. Full explanations can be read [in this article](https://codesymphony.co/dont-do_shortcode/)

--- a/docs/advanced/webpack.md
+++ b/docs/advanced/webpack.md
@@ -3,6 +3,8 @@ id: webpack
 title: Webpack
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--boilerplate-red?style=for-the-badge&logo=wordpress&labelColor=2a2a2a)](https://github.com/infinum/eightshift-boilerplate/blob/develop/webpack.config.js)
+
 At its core, webpack is a static module bundler for modern JavaScript applications. When webpack processes your application, it internally builds a dependency graph which maps every module your project needs and generates one or more bundles. Learn more about webpack [here](https://webpack.js.org/concepts/).
 
 Look at how the config is set up on [Eightshift Boilerplate repo](https://github.com/infinum/eightshift-boilerplate/blob/develop/webpack.config.js).

--- a/docs/guides/blocks-block-from-components.md
+++ b/docs/guides/blocks-block-from-components.md
@@ -3,7 +3,9 @@ id: blocks-block-from-components
 title: Creating Block from Components
 ---
 
-You may wonder: what is the difference between components and blocks? Aren't they the same thing? 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--frontend--libs-yellow?style=for-the-badge&logo=javascript&labelColor=2a2a2a)](https://github.com/infinum/eightshift-frontend-libs/tree/develop/blocks/init/src/blocks/custom/button)
+
+You may wonder: what is the difference between components and blocks? Aren't they the same thing?
 
 They are similar, but not the same. Components are, for lack of a better word, _dumb_. They aren't bothered with the context and they are **reusable**.
 This is the key word in this whole ordeal. One component may be reused in different blocks. Also, the main difference is that the component is not registered in WordPress; its sole purpose is to provide reusable parts for your blocks.
@@ -24,7 +26,7 @@ First we'll create a block in the `src/blocks/custom/card` folder. The folder st
 | |card.php
 | |card-style.scss
 | |manifest.json
-``` 
+```
 
 The `manifest.json` will hold all the default attributes and data about the new block
 
@@ -202,8 +204,8 @@ export const Card = (props) => {
 };
 ```
 
-Here we'll use our ready made component (built out of other components - reusability), and wrap it in [React Fragment](https://reactjs.org/docs/fragments.html). It is a pattern used so that we can return multiple elements.  
-Another thing you'll note is the usage of `<InspectorControls />` [component](https://github.com/WordPress/gutenberg/tree/master/packages/block-editor/src/components/inspector-controls). It is used to display settings of the block in the sidebar (in our case our options that contain the image upload component).  
+Here we'll use our ready made component (built out of other components - reusability), and wrap it in [React Fragment](https://reactjs.org/docs/fragments.html). It is a pattern used so that we can return multiple elements.
+Another thing you'll note is the usage of `<InspectorControls />` [component](https://github.com/WordPress/gutenberg/tree/master/packages/block-editor/src/components/inspector-controls). It is used to display settings of the block in the sidebar (in our case our options that contain the image upload component).
 Lastly, both our `<CardEditor />` and `<InspectorControls />` are wrapped in the `<Fragment />` wrapper due to Reacts one top-level element rule. If your block doesn't have Options, you can only have `<CardEditor />` component in here.
 
 ### PHP view
@@ -277,7 +279,7 @@ Notice how we used
 ?>
 ```
 
-To render out our `image` component. Again, we're showing the power of reusability here. 
+To render out our `image` component. Again, we're showing the power of reusability here.
 
 ### Styling
 

--- a/docs/guides/blocks-filer-block-attributes-override.md
+++ b/docs/guides/blocks-filer-block-attributes-override.md
@@ -3,6 +3,8 @@ id: blocks-filter-block-attributes-override
 title: Filter Attributes Override
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--libs-blue?style=for-the-badge&logo=php&labelColor=2a2a2a)](https://github.com/infinum/eightshift-libs/blob/develop/src/blocks/class-blocks.php)
+
 This filter gives you the ability to hook your changes to block/wrapper attributes after they are registered in the block editor but before they are rendered in React.
 
 The usage of this method is vast. You can, for example, use it to provide different block/wrapper defaults depending on the post type. For example, you have a button block that you want to have the default color red, but on the post type `post`, you want that button to be black by default. Using this hook, you can easily do this.

--- a/docs/guides/blocks-get-actions-helper.md
+++ b/docs/guides/blocks-get-actions-helper.md
@@ -3,15 +3,16 @@ id: blocks-get-actions-helper
 title: GetActions Helper
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--frontend--libs-yellow?style=for-the-badge&logo=javascript&labelColor=2a2a2a)](https://github.com/infinum/eightshift-frontend-libs/blob/develop/scripts/get-actions.js)
+
+
 This helper will create attributes actions from blocks `manifest.json`.
 Actions are passed in child components in order to update props on an event (`onChange`, `onClick`, etc.).
 
 ## Default Attribute
 
-Default function output is `onChange` + attribute name.  
+Default function output is `onChange` + attribute name.
 Example: `onChangeContent`.
-
-Helper is located [here](https://github.com/infinum/eightshift-frontend-libs/blob/d14c02804c1e55fc4ca11af0546a40205fee93a7/scripts/get-actions.js).
 
 `manifest.json`
 

--- a/docs/guides/blocks-render-block-view-helper.md
+++ b/docs/guides/blocks-render-block-view-helper.md
@@ -3,9 +3,9 @@ id: blocks-render-block-view-helper
 title: Render Block View Helper
 ---
 
-Locate and return template part with passed attributes for a block.
+[![docs-source](https://img.shields.io/badge/source-eigthshift--libs-blue?style=for-the-badge&logo=php&labelColor=2a2a2a)](https://github.com/infinum/eightshift-libs/blob/master/src/blocks/class-blocks.php)
 
-Helper is located in the [eightshift-libs](https://github.com/infinum/eightshift-libs/blob/935e7bc777094d7518950316a45061f7675cf7ed/src/blocks/class-blocks.php#L295) library.
+Locate and return template part with passed attributes for a block.
 
 ### Usage
 

--- a/docs/guides/blocks-structure-block-item.md
+++ b/docs/guides/blocks-structure-block-item.md
@@ -3,6 +3,8 @@ id: blocks-structure-block-item
 title: Block Structure Item
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--frontend--libs-yellow?style=for-the-badge&logo=javascript&labelColor=2a2a2a)](https://github.com/infinum/eightshift-frontend-libs/tree/develop/blocks/init/src/blocks/custom/example)
+
 In order for the library to work and register blocks dynamically, a specific folder structure and naming must be followed. Individual blocks are placed in the `custom` folder.
 
 Your custom block structure should look like this:
@@ -27,7 +29,7 @@ Components folder holds three files `block-name-options.js`, `block-name-editor.
 
 ### block-name-block.js
 This file represents the `edit` callback method used in WordPress `registerBlockType` method.
-We are not using the `save` callback component because this library is used to create dynamic blocks. The `edit` method describes how your block will be rendered in the editor once the block is used. 
+We are not using the `save` callback component because this library is used to create dynamic blocks. The `edit` method describes how your block will be rendered in the editor once the block is used.
 
 ### block-name.php
 This file will pass the properties you've set in the `block-name.js` and use the `render_block_view()` method from the [eightshift libs](https://github.com/infinum/eightshift-blocks/blob/44c168f74ba57cc596f352d34a3e4c6441fc2b8b/src/class-blocks.php#L193). It is used to provide frontend layout for your block.
@@ -35,11 +37,11 @@ This file will pass the properties you've set in the `block-name.js` and use the
 ### block-name-editor.scss
 Holds only the editor styling for the block. You should be using this file to override styles in the editor set by the component. In 90% of cases, you will not need to write any overrides here. But if you are using any columns layout like a grid, flex, etc., you may need to add some corrections.
 
-Corrections in the columns layout are necessary because Block Editor editor adds its additional HTML and you can't change it.  
+Corrections in the columns layout are necessary because Block Editor editor adds its additional HTML and you can't change it.
 _This file is optional_.
 
 ### block-name-style.scss
-Holds all the frontend and editor styling for the component. Like the above file, in most cases it can be avoided.  
+Holds all the frontend and editor styling for the component. Like the above file, in most cases it can be avoided.
 _This file is optional_.
 
 ### manifest.json

--- a/docs/guides/blocks-structure-component.md
+++ b/docs/guides/blocks-structure-component.md
@@ -3,6 +3,8 @@ id: blocks-structure-component
 title: Component Structure
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--frontend--libs-yellow?style=for-the-badge&logo=javascript&labelColor=2a2a2a)](https://github.com/infinum/eightshift-frontend-libs/tree/develop/blocks/init/src/blocks/components/button)
+
 Component naming and folder structure are not as strict as in the case of the block, but for the sake of consistency, it would be better to follow the same principles.
 
 Basic component structure should like something this:
@@ -43,4 +45,4 @@ This file contains the editor and the frontend styles for the component. These s
 
 #### Note on the component styles
 
-Component styles should only style the inner component layout and styles such as font sizes, alignment, etc. Any layout placement should be handled either by the wrapper, or a layout. 
+Component styles should only style the inner component layout and styles such as font sizes, alignment, etc. Any layout placement should be handled either by the wrapper, or a layout.

--- a/docs/guides/blocks-structure.md
+++ b/docs/guides/blocks-structure.md
@@ -3,7 +3,10 @@ id: blocks-structure
 title: Blocks Structure
 ---
 
-In order for the library to work and register blocks dynamically, a specific folder structure and naming must be followed. 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--frontend--libs-yellow?style=for-the-badge&logo=javascript&labelColor=2a2a2a)](https://github.com/infinum/eightshift-frontend-libs/tree/develop/blocks/init/src/blocks/)
+
+
+In order for the library to work and register blocks dynamically, a specific folder structure and naming must be followed.
 
 Your folder structure should like this:
 
@@ -28,7 +31,7 @@ This folder contains all the Block Editor blocks defined in your project. Each b
 This folder contains all the additional javascript, images, fonts and style functionality for the blocks that you only need to use on the frontend and in the editor (admin).
 
 ### components
-This folder contains all the components that are shared across blocks. Components are not registered as blocks. 
+This folder contains all the components that are shared across blocks. Components are not registered as blocks.
 
 ### custom
 This folder contains all the custom Block Editor blocks defined and used in your project.

--- a/docs/guides/columns-post-type.md
+++ b/docs/guides/columns-post-type.md
@@ -3,6 +3,8 @@ id: columns-post-type
 title: Post Type
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--libs-blue?style=for-the-badge&logo=php&labelColor=2a2a2a)](https://github.com/infinum/eightshift-libs/blob/develop/src/columns/class-base-post-type-columns.php)
+
 Post Type Column class is located in `Eightshift Libs`. To extend it use `Eightshift_Libs\Columns\Base_Post_Type_Columns` class.
 
 ## Example:

--- a/docs/guides/columns-taxonomy.md
+++ b/docs/guides/columns-taxonomy.md
@@ -3,6 +3,8 @@ id: columns-taxonomy
 title: Taxonomy
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--libs-blue?style=for-the-badge&logo=php&labelColor=2a2a2a)](https://github.com/infinum/eightshift-libs/blob/develop/src/columns/class-base-taxonomy-columns.php)
+
 Taxonomy Column class is located in `Eightshift Libs`. To extend it use `Eightshift_Libs\Columns\Base_Taxonomy_Columns` class.
 
 ## Example:

--- a/docs/guides/columns-user.md
+++ b/docs/guides/columns-user.md
@@ -3,6 +3,8 @@ id: columns-user
 title: User
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--libs-blue?style=for-the-badge&logo=php&labelColor=2a2a2a)](https://github.com/infinum/eightshift-libs/blob/develop/src/columns/class-base-user-columns.php)
+
 User Column class is located in `Eightshift Libs`. To extend it use `Eightshift_Libs\Columns\Base_User_Columns` class.
 
 ## Example:

--- a/docs/guides/config.md
+++ b/docs/guides/config.md
@@ -3,6 +3,8 @@ id: config
 title: Project Config
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--boilerplate-red?style=for-the-badge&logo=wordpress&labelColor=2a2a2a)](https://github.com/infinum/eightshift-boilerplate/blob/develop/src/class-config.php)
+
 Project config is located in `src/class-config.php`, and it extends `Eightshift_Libs\Core\Config` class from the lib.
 
 This class is used to define all the important methods for your project:

--- a/docs/guides/di-container.md
+++ b/docs/guides/di-container.md
@@ -3,6 +3,8 @@ id: di-container
 title: Dependency injection container
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--libs-blue?style=for-the-badge&logo=php)](https://github.com/infinum/eightshift-libs/blob/develop/src/class-main.php)
+
 Dependency injection is a way of implementing inversion of control design pattern. It's used to handle the dependencies between multiple classes without the direct instantiation of one class in another - which causes tight coupling in the code, and makes it less testable and harder to maintain.
 
 Eightshift libs are using [PHP-DI](http://php-di.org/) as an implementation of a dependency injection container. We'll explain the implementation by following the [eightshift-boilerplate](https://github.com/infinum/eightshift-boilerplate/blob/develop/src/class-main.php) example.

--- a/docs/guides/di-container.md
+++ b/docs/guides/di-container.md
@@ -3,7 +3,7 @@ id: di-container
 title: Dependency injection container
 ---
 
-[![docs-source](https://img.shields.io/badge/source-eigthshift--libs-blue?style=for-the-badge&logo=php)](https://github.com/infinum/eightshift-libs/blob/develop/src/class-main.php)
+[![docs-source](https://img.shields.io/badge/source-eigthshift--libs-blue?style=for-the-badge&logo=php&labelColor=2a2a2a)](https://github.com/infinum/eightshift-libs/blob/develop/src/class-main.php)
 
 Dependency injection is a way of implementing inversion of control design pattern. It's used to handle the dependencies between multiple classes without the direct instantiation of one class in another - which causes tight coupling in the code, and makes it less testable and harder to maintain.
 

--- a/docs/guides/enqueue.md
+++ b/docs/guides/enqueue.md
@@ -3,6 +3,8 @@ id: enqueue
 title: Enqueue
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--libs-blue?style=for-the-badge&logo=php&labelColor=2a2a2a)](https://github.com/infinum/eightshift-libs/tree/develop/src/enqueue)
+
 Manifest class is located in `Eightshift Libs`. To extend it, use one of the following classes:
 * `Eightshift_Libs\Enqueue\Enqueue_Admin` class.
 * `Eightshift_Libs\Enqueue\Enqueue_Blocks` class.

--- a/docs/guides/extending-classes.md
+++ b/docs/guides/extending-classes.md
@@ -3,6 +3,8 @@ id: extending-classes
 title: Extending Classes
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--libs-blue?style=for-the-badge&logo=php&labelColor=2a2a2a)](https://github.com/infinum/eightshift-libs)
+
 We are providing abstract classes, interfaces, helpers, dependency injection and namespaces for your project. In general, you can use anything as-is from the vendor library, or you can modify/add the functionality of existing classes by extending them in your project.
 
 If you are familiar with the extending classes (object inheritance) in PHP language then you can just skip this chapter but for the rest of you here is an awesome description on how it works:

--- a/docs/guides/i18n.md
+++ b/docs/guides/i18n.md
@@ -3,6 +3,8 @@ id: i18n
 title: i18n
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--libs-blue?style=for-the-badge&logo=php&labelColor=2a2a2a)](https://github.com/infinum/eightshift-libs/tree/develop/src/i18n)
+
 Language translation class is located in `Eightshift Libs`. To extend it use `Eightshift_Libs\I18n\I18n` class.
 
 To provide language translation put all your `.po`and `.mo` files inside `src/i18n` folder.

--- a/docs/guides/login.md
+++ b/docs/guides/login.md
@@ -2,6 +2,7 @@
 id: login
 title: Login
 ---
+[![docs-source](https://img.shields.io/badge/source-eigthshift--libs-blue?style=for-the-badge&logo=php&labelColor=2a2a2a)](https://github.com/infinum/eightshift-libs/blob/develop/src/login/class-login.php)
 
 Login class is located in `Eightshift Libs`. To extend it use `Eightshift_Libs\Login\Login` class.
 

--- a/docs/guides/manifest.md
+++ b/docs/guides/manifest.md
@@ -3,6 +3,8 @@ id: manifest
 title: Manifest
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--libs-blue?style=for-the-badge&logo=php&labelColor=2a2a2a)](https://github.com/infinum/eightshift-libs/tree/develop/src/manifest)
+
 Manifest class is located in `Eightshift Libs`. To extend it, use `Eightshift_Libs\Manifest\Manifest` class.
 
 In the build process, Webpack creates all static files and also `manifest.json` inside the `public` folder. The manifest file contains a key/value list that we use to call the location of the assets dynamically.

--- a/docs/guides/media.md
+++ b/docs/guides/media.md
@@ -3,6 +3,8 @@ id: media
 title: Media
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--boilerplate-red?style=for-the-badge&logo=wordpress&labelColor=2a2a2a)](https://github.com/infinum/eightshift-boilerplate/blob/develop/src/media/class-media.php)
+
 Media class is located in `project`. It extends `Eightshift_Libs\Media\Media` class.
 
 This class is used to add all custom project implementation for media like adding custom image size, enabling SVG image, etc.

--- a/docs/guides/menu.md
+++ b/docs/guides/menu.md
@@ -3,6 +3,8 @@ id: menu
 title: Menu
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--boilerplate-red?style=for-the-badge&logo=wordpress&labelColor=2a2a2a)](https://github.com/infinum/eightshift-boilerplate/blob/develop/src/menu/class-menu.php)
+
 Menu class is located in `project`. It extends `Eightshift_Libs\Menu\Menu` class.
 
 This class is used to add all custom project implementation for menus.

--- a/docs/guides/post-type.md
+++ b/docs/guides/post-type.md
@@ -3,6 +3,8 @@ id: post-type
 title: Post Type
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--libs-blue?style=for-the-badge&logo=php)](https://github.com/infinum/eightshift-libs/blob/develop/src/custom-post-type/class-base-post-type.php)
+
 When working on a WordPress project it is possible that, at one point, you will need to register a Custom Post Type.
 
 In that case, we have prepared an easy way for you to register a new post type by following these steps with the following code example:

--- a/docs/guides/post-type.md
+++ b/docs/guides/post-type.md
@@ -3,7 +3,7 @@ id: post-type
 title: Post Type
 ---
 
-[![docs-source](https://img.shields.io/badge/source-eigthshift--libs-blue?style=for-the-badge&logo=php)](https://github.com/infinum/eightshift-libs/blob/develop/src/custom-post-type/class-base-post-type.php)
+[![docs-source](https://img.shields.io/badge/source-eigthshift--libs-blue?style=for-the-badge&logo=php&labelColor=2a2a2a)](https://github.com/infinum/eightshift-libs/blob/develop/src/custom-post-type/class-base-post-type.php)
 
 When working on a WordPress project it is possible that, at one point, you will need to register a Custom Post Type.
 

--- a/docs/guides/rest-field-example.md
+++ b/docs/guides/rest-field-example.md
@@ -3,6 +3,8 @@ id: rest-field-example
 title: Field Example
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--libs-blue?style=for-the-badge&logo=php&labelColor=2a2a2a)](https://github.com/infinum/eightshift-libs/tree/master/src/rest)
+
 REST Field class is located in `Eightshift Libs`. To extend it, use `use Eightshift_Libs\Rest\Base_Field` class. This is an abstract class.
 
 ## Example:

--- a/docs/guides/rest-intro.md
+++ b/docs/guides/rest-intro.md
@@ -3,6 +3,8 @@ id: rest-intro
 title: Rest Intro
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--libs-blue?style=for-the-badge&logo=php&labelColor=2a2a2a)](https://github.com/infinum/eightshift-libs/tree/master/src/rest)
+
 When you are working on a more complex WordPress project at one point, you will have to make a new Rest API route or add a new API field to the existing route, or something else.
 
 We have prepared 4 interfaces:

--- a/docs/guides/rest-routes-example.md
+++ b/docs/guides/rest-routes-example.md
@@ -3,6 +3,8 @@ id: rest-route-example
 title: Route Example
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--libs-blue?style=for-the-badge&logo=php&labelColor=2a2a2a)](https://github.com/infinum/eightshift-libs/tree/master/src/rest)
+
 To implement the new Rest API Route, you would need to do a few things, but for this example, we will use this folder structure:
 ```php
 

--- a/docs/guides/taxonomy.md
+++ b/docs/guides/taxonomy.md
@@ -3,6 +3,8 @@ id: taxonomy
 title: Taxonomy
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--libs-blue?style=for-the-badge&logo=php&labelColor=2a2a2a)](https://github.com/infinum/eightshift-libs/tree/develop/src/custom-taxonomy)
+
 Custom Taxonomy class is located in `Eightshift Libs`. To extend it, use `Eightshift_Libs\Custom_Taxonomy\Base_Taxonomy` class. This is an abstract class.
 
 ## Example:

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -4,6 +4,8 @@ title: Create new WordPress plugin
 sidebar_label: Plugin Setup
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--frontend--libs-yellow?style=for-the-badge&logo=javascript)](https://github.com/infinum/eightshift-frontend-libs/tree/develop/setup/create-wp-project)
+
 Eightshift boilerplate contains all the tools you need to start building a modern WordPress plugin, using all the latest front end development tools.
 
 [Please go here if you wish to setup a theme instead](theme).
@@ -13,7 +15,7 @@ Eightshift boilerplate contains all the tools you need to start building a moder
 1. [Node.js](https://nodejs.org/en/)
 2. [Composer](https://getcomposer.org/)
 
-## Quick start 
+## Quick start
 Let's create a **new plugin**!
 
 Navigate to your WordPress plugin folder (`wp-content/plugins`) and run the following command:
@@ -22,7 +24,7 @@ Navigate to your WordPress plugin folder (`wp-content/plugins`) and run the foll
 npx create-wp-project plugin
 ```
 
-Script will prompt you for some info and install a new plugin. After it's finished, you can **activate the plugin through WP Admin Dashboard**. 
+Script will prompt you for some info and install a new plugin. After it's finished, you can **activate the plugin through WP Admin Dashboard**.
 
 To start developing run this command from plugin's root folder:
 

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -4,7 +4,7 @@ title: Create new WordPress plugin
 sidebar_label: Plugin Setup
 ---
 
-[![docs-source](https://img.shields.io/badge/source-eigthshift--frontend--libs-yellow?style=for-the-badge&logo=javascript)](https://github.com/infinum/eightshift-frontend-libs/tree/develop/setup/create-wp-project)
+[![docs-source](https://img.shields.io/badge/source-eigthshift--frontend--libs-yellow?style=for-the-badge&logo=javascript&labelColor=2a2a2a)](https://github.com/infinum/eightshift-frontend-libs/tree/develop/setup/create-wp-project)
 
 Eightshift boilerplate contains all the tools you need to start building a modern WordPress plugin, using all the latest front end development tools.
 

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -4,6 +4,8 @@ title: Create new WordPress theme
 sidebar_label: Theme Setup
 ---
 
+[![docs-source](https://img.shields.io/badge/source-eigthshift--frontend--libs-yellow?style=for-the-badge&logo=javascript)](https://github.com/infinum/eightshift-frontend-libs/tree/develop/setup/create-wp-project)
+
 Eightshift boilerplate contains all the tools you need to start building a modern WordPress theme, using all the latest front end development tools.
 
 [Please go here if you wish to setup a plugin instead](plugin).
@@ -13,7 +15,7 @@ Eightshift boilerplate contains all the tools you need to start building a moder
 1. [Node.js](https://nodejs.org/en/)
 2. [Composer](https://getcomposer.org/)
 
-## Quick start 
+## Quick start
 Let's create a new theme!
 
 Navigate to your WordPress theme folder and run the following command:
@@ -26,7 +28,7 @@ Script will prompt you for theme name and local development url (used for Browse
 
 ![](https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/package/setup.gif)
 
-After the script is finished, you can activate the theme through WP Admin Dashboard. 
+After the script is finished, you can activate the theme through WP Admin Dashboard.
 
 To start developing run this command from theme's root folder:
 

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -4,7 +4,7 @@ title: Create new WordPress theme
 sidebar_label: Theme Setup
 ---
 
-[![docs-source](https://img.shields.io/badge/source-eigthshift--frontend--libs-yellow?style=for-the-badge&logo=javascript)](https://github.com/infinum/eightshift-frontend-libs/tree/develop/setup/create-wp-project)
+[![docs-source](https://img.shields.io/badge/source-eigthshift--frontend--libs-yellow?style=for-the-badge&logo=javascript&labelColor=2a2a2a)](https://github.com/infinum/eightshift-frontend-libs/tree/develop/setup/create-wp-project)
 
 Eightshift boilerplate contains all the tools you need to start building a modern WordPress theme, using all the latest front end development tools.
 

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -72,6 +72,11 @@ article a:hover {
   color: var(--base-walnut-color);
 }
 
+article p img {
+  margin-left: 0;
+  display: inline-block;
+}
+
 .toc .toggleNav ul li a {
   color: var(--base-parl-color);
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/41635034/75608652-c10a6400-5b01-11ea-8533-ea090930f995.png)
![image](https://user-images.githubusercontent.com/41635034/75608657-cd8ebc80-5b01-11ea-9e39-a151f97f72e3.png)
![image](https://user-images.githubusercontent.com/41635034/76019297-c57bb600-5f21-11ea-9fb5-a12df2bb0541.png)


Add some image styles so badges look good and can be stacked in a single row
Add two versions of custom badges for showing where the examples are located (libs or frontend libs)
Removed links to libs in doc pages (we have badges now)

Removed some trailing whitespaces

Add one more badge image for Eightshift Boilerplate
Add doc badges to the rest of the chapters
Add short explanation of the `Shrtcode` class