### PR TITLE
Fix "Eigthshift" typo on Versions page

### DIFF
--- a/website/docs/versions.md
+++ b/website/docs/versions.md
@@ -5,13 +5,13 @@ title: Versions
 
 Now that you understand what makes Eightshift tick, here is a quick reminder about what library versions this documentation refers to.
 
-[![docs-source](https://img.shields.io/badge/version--6.0.0-eigthshift--boilerplate-red?style=for-the-badge&logo=)](https://github.com/infinum/eightshift-boilerplate)
+[![docs-source](https://img.shields.io/badge/version--6.0.0-eightshift--boilerplate-red?style=for-the-badge&logo=)](https://github.com/infinum/eightshift-boilerplate)
 
-[![docs-source](https://img.shields.io/badge/version--2.0.0-eigthshift--boilerplate--plugin-important?style=for-the-badge&logo=)](https://github.com/infinum/eightshift-boilerplate)
+[![docs-source](https://img.shields.io/badge/version--2.0.0-eightshift--boilerplate--plugin-important?style=for-the-badge&logo=)](https://github.com/infinum/eightshift-boilerplate)
 
-[![docs-source](https://img.shields.io/badge/version--4.0.0-eigthshift--libs-blue?style=for-the-badge&logo=)](https://github.com/infinum/eightshift-libs)
+[![docs-source](https://img.shields.io/badge/version--4.0.0-eightshift--libs-blue?style=for-the-badge&logo=)](https://github.com/infinum/eightshift-libs)
 
-[![docs-source](https://img.shields.io/badge/version--5.0.0-eigthshift--frontend--libs-yellow?style=for-the-badge&logo=)](https://github.com/infinum/eightshift-frontend-libs)
+[![docs-source](https://img.shields.io/badge/version--5.0.0-eightshift--frontend--libs-yellow?style=for-the-badge&logo=)](https://github.com/infinum/eightshift-frontend-libs)
 
 # Now you must decide!
 


### PR DESCRIPTION
Fixes a typo on the Versions page where Eightshift was spelled as Eigthshift.