### PR TITLE
Import useState, useEffect in Showcase grid

### DIFF
--- a/website/src/theme/sections/showcase-grid/showcase-grid.js
+++ b/website/src/theme/sections/showcase-grid/showcase-grid.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import Heading from '../../components/heading/heading';
 import Container from '../../components/container/container';


### PR DESCRIPTION
# Description

useState and useEffect weren't imported previously in `showcase-grid.js` so the build failed.