### PR TITLE
Fix intro image position on mobile screens

### DIFF
--- a/website/src/theme/sections/intro/intro.scss
+++ b/website/src/theme/sections/intro/intro.scss
@@ -69,7 +69,7 @@ $intro: (
   image: (
     mobile: (
       position: relative,
-      margin: 0 (-$base-gutter-size * 2) 40px,
+      margin: 0 (-$base-gutter-size) 40px,
       display: flex,
       justify-content: flex-end,
     ),


### PR DESCRIPTION
# Description
Container where intro image is placed has `padding-left` and `padding-right` **25px**. But the element itself had `margin-left` and `margin-right` **-50px**. That caused horizontal scrolling and all other elements didn't seem to have full width or similar.

<!--- Write in detail what you did and what issue did you fix with this PR. -->

# Screenshots / Videos
<img width="553" alt="es-docs-1" src="https://user-images.githubusercontent.com/19992824/164230835-9a429137-bfce-4344-8197-cbb063ffcef8.png">
<img width="554" alt="es-docs-2" src="https://user-images.githubusercontent.com/19992824/164230855-142f3a35-9c42-42d6-91d3-dab0c424ef82.png">

<!--- Show us what you did. -->

