### PR TITLE
Fix links in v5 Frontend Stuff > Global Settings

### DIFF
--- a/website/docs/legacy/v5/basics/global-settings.md
+++ b/website/docs/legacy/v5/basics/global-settings.md
@@ -6,13 +6,13 @@ sidebar_label: Global Settings
 
 [![docs-source](https://img.shields.io/badge/source-eigthshift--frontend--libs-yellow?style=for-the-badge&logo=javascript&labelColor=2a2a2a)](https://github.com/infinum/eightshift-frontend-libs)
 
-> This chapter is only relevant in setups that don't use CSS variables. If you are using CSS variables please skip to the [Blocks Styles chapter](blocks-styles) chapter.
+> This chapter is only relevant in setups that don't use CSS variables. If you are using CSS variables please skip to the [Blocks Styles chapter](./blocks-styles) chapter.
 
 Ok, this is the part that we are incredibly proud of. Did you know that you can pass values from the JSON manifest or some other file directly to SCSS? Yes, we had the same facial expression when we found out. For this to work, we used Webpack and its excellent features.
 
 > This feature comes only with the block setup.
 
-If you used the `setup_theme` setup, you are all set. If not, please visit the [blocks chapter](blocks) for more details.
+If you used the `setup_theme` setup, you are all set. If not, please visit the [blocks chapter](./blocks) for more details.
 
 ## Why do we use this?
 


### PR DESCRIPTION
# Description

This PR fixes two links in the legacy v5 docs on the Basics > Frontend Stuff > [Global Settings](https://infinum.github.io/eightshift-docs/docs/legacy/v5/basics/global-settings/) page:

# Screenshots / Videos

![image](https://user-images.githubusercontent.com/22823970/168090188-63acc5aa-3a4e-4bb6-8e80-dddcb36eecdc.png)
