### PR TITLE
Add concrete examples for Swiper 8.x.x migration

### DIFF
--- a/website/docs/migrations/7-8.md
+++ b/website/docs/migrations/7-8.md
@@ -71,6 +71,18 @@ Swiper is not a dependency of Eightshift Boilerplate, but if you are using Swipe
 
 please check Swiper's `package.json` in `node_modules/swiper/package.json` and find the `exports` key, find the styles you are using and replace the path for the correct export path. Please note that this export can change depending on the Swiper version you are using.
 
+For example, for Swiper `8.x.x`, you should replace
+```scss
+@import '~swiper/swiper.scss';
+@import '~swiper/modules/pagination/pagination.scss';
+```
+
+with
+
+```scss
+@import '~swiper/css';
+@import '~swiper/css/pagination';
+```
 
 ### Storybook changes:
 


### PR DESCRIPTION
# Description
To make it easier to migrate to 8.x.x version of Swiper, which introduced a different way of importing CSS, a small concrete example was added because the "look inside `package.json` within `node_modules`" isn't as easy anymore 😄 

# Screenshots / Videos

\-

# Linked documentation PR

\-