### PR TITLE
Added Collapsible Sidebar Functionality

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -17,6 +17,7 @@ module.exports = {
 		}
 	],
 	themeConfig: {
+		
 		navbar: {
 			logo: {
 				alt: 'Eightshift DevKit Logo',
@@ -115,6 +116,11 @@ module.exports = {
 			disableSwitch: true,
 			respectPrefersColorScheme: false,
 		},
+		docs: {
+			sidebar: {
+				autoCollapseCategories: true,
+			}
+		},
 		trailingSlash: false
 	},
 	presets: [
@@ -123,6 +129,7 @@ module.exports = {
 			{
 				docs: {
 					sidebarPath: require.resolve('./sidebars.js'),
+					sidebarCollapsible: true,
 				},
 				gtag: {
 					trackingID: 'GTM-P5GG5DH',


### PR DESCRIPTION
This PR fixes issue no: #275 

# Description

The sidebar will now only showcase the category the user clicks on, rest all other categories will be collapsed automatically.

# Screenshots / Videos

<img src="https://github.com/infinum/eightshift-docs/assets/97957777/deb9b37b-e292-48e0-be09-133685bb9b0a" width=200>

Suppose I want to refer the documentations of `Migrations` category, then as soon as I clicked on `Migrations` category, all other categories will be collapsed automatically.


