### PR TITLE
Fix command and typo

### DIFF
--- a/website/forms/php/wp-cli.md
+++ b/website/forms/php/wp-cli.md
@@ -20,8 +20,8 @@ After adding a custom stylesheet, make sure to deactivate built-in styles in Glo
 :::
 
 ``` bash
-wp eightshift-forms esf copy_stylesheet_set
+wp eightshift-forms copy_stylesheet_set
 ```
 
 **Available options**:
-* `--additional-path=<additional-path>` - Set additional path relative from the active theme. Example. `src/Block/components/`.
+* `--additional-path=<additional-path>` - Set additional path relative from the active theme. Example. `src/Blocks/components`.


### PR DESCRIPTION
# Description

Found deprecated command and fixed example typo.

# Screenshots / Videos

![image](https://github.com/infinum/eightshift-docs/assets/135589039/f89b03f1-b4b2-4a55-af8c-b4a8c6680ceb)

# Linked documentation PR

https://eightshift.com/forms/php/wp-cli
