### PR TITLE
FE libs tailwind - part 4.99

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "eightshift-docs",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/website/package.json
+++ b/website/package.json
@@ -34,7 +34,7 @@
 	"dependencies": {
 		"@docusaurus/core": "^3.4.0",
 		"@docusaurus/preset-classic": "^3.4.0",
-		"@eightshift/ui-components": "^1.2.0",
+		"@eightshift/ui-components": "^1.2.1",
 		"@infinum/docusaurus-theme": "^0.5.0",
 		"@mdx-js/react": "^3.0.1",
 		"@wp-playground/client": "^0.7.20",

--- a/website/src/theme/styles.css
+++ b/website/src/theme/styles.css
@@ -23,12 +23,12 @@
 	width: 3.25rem !important;
 	height: 3.25rem !important;
 
-	svg {
-		width: 1.5rem !important;
-		height: 1.5rem !important;
-	}
 }
 
+.esd-icon-showcase-button svg {
+	width: 1.5rem !important;
+	height: 1.5rem !important;
+}
 
 .esd-legacy-docs-iframe {
 	min-width: 64vw;

--- a/website/src/theme/styles.css
+++ b/website/src/theme/styles.css
@@ -20,18 +20,18 @@
 }
 
 .esd-icon-showcase-button {
-	inline-size: 3.25rem !important;
-	block-size: 3.25rem !important;
+	width: 3.25rem !important;
+	height: 3.25rem !important;
 
 	svg {
-		inline-size: 1.5rem !important;
-		block-size: 1.5rem !important;
+		width: 1.5rem !important;
+		height: 1.5rem !important;
 	}
 }
 
 
 .esd-legacy-docs-iframe {
-	min-inline-size: 64vw;
+	min-width: 64vw;
 
 	border: 1px solid #D1D5DB !important;
 	border-radius: 0.5rem !important;


### PR DESCRIPTION
# Description

Looks like Docusaurus build system doesn't support CSS logical properties or CSS nesting 🥲

Also updated ES UIC to 1.2.1 and updated the Playground demo (just ES UIC update).

# Screenshots / Videos

\-

# Linked documentation PR

\-