### PR TITLE
Add Strauss migration guide

### DIFF
--- a/website/docs/migrations/11-12.md
+++ b/website/docs/migrations/11-12.md
@@ -218,3 +218,71 @@ const projectConfig = {
 	},
 };
 ```
+
+### Replace Imposter with Strauss
+
+**Migration time: ~10min.**
+
+We have removed Imposter and replaced it with Strauss for prefixing namespaces.
+
+1. Add `/vendor-prefixed` to your **.gitignore** file
+2. Add **strauss.phar** to your theme root. You can get it [here](https://github.com/BrianHenryIE/strauss)
+3. Make the following changes in your **composer.json** file:
+
+- remove `typisttech/imposter-plugin`
+- add the following in the `scripts` section:
+```json
+"prefix-namespaces": [
+	"@php strauss.phar",
+	"composer dump-autoload"
+],
+"post-install-cmd": [
+	"@php strauss.phar",
+	"composer dump-autoload"
+],
+"post-update-cmd": [
+	"@php strauss.phar",
+	"composer dump-autoload"
+]
+```
+- remove `imposter` from the `extra` section and add the following:
+```json
+"strauss": {
+	"namespace_prefix": "ProjectNameVendor",
+	"exclude_from_prefix": {
+		"file_patterns": ["/Example.php$/"]
+	}
+}
+```
+
+4. Update **functions.php** file
+```php
+/**
+ * Bailout, if the theme is not loaded via Composer.
+ */
+if (!\file_exists(__DIR__ . '/vendor/autoload.php')) {
+	return;
+}
+
+/**
+ * Require the Composer autoloader.
+ */
+$loader = require __DIR__ . '/vendor/autoload.php';
+
+/**
+ * Require the Composer autoloader for the prefixed libraries.
+ */
+if (\file_exists(__DIR__ . '/vendor-prefixed/autoload.php')) {
+	require __DIR__ . '/vendor-prefixed/autoload.php';
+}
+```
+5. Add the following line in your **phpcs.xml.dist**:
+```
+<exclude-pattern>*/vendor-prefixed/*</exclude-pattern>
+```
+6. Add the following line in your **phpstan.neon.dist** in `boostrapFiles` section:
+```
+- vendor-prefixed/autoload.php
+```
+
+Once you have made these changes, remove the `vendor` folder and run `composer install`.


### PR DESCRIPTION
Changes:
 - added instructions how to replace Imposter with Strauss to Migration Guide 11-12
