### PR TITLE
updating packages

### DIFF
--- a/website/bun.lock
+++ b/website/bun.lock
@@ -5,22 +5,23 @@
     "": {
       "name": "@eightshift/docs",
       "dependencies": {
-        "@docusaurus/core": "^3.9.2",
-        "@docusaurus/preset-classic": "^3.9.2",
-        "@eightshift/ui-components": "^6.3.0",
+        "@docusaurus/core": "^3.10.1",
+        "@docusaurus/preset-classic": "^3.10.1",
+        "@eightshift/ui-components": "^7.3.0",
         "@infinum/docusaurus-theme": "^0.6.0",
         "@mdx-js/react": "^3.1.1",
         "@wp-playground/client": "^2.0.22",
-        "caniuse-lite": "^1.0.30001781",
+        "caniuse-lite": "^1.0.30001792",
         "clsx": "^2.1.1",
         "es-text-loader": "file:plugins/es-text-loader",
         "prism-react-renderer": "^2.4.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-scripts": "^5.0.1",
+        "use-sync-external-store": "^1.6.0",
       },
       "devDependencies": {
-        "baseline-browser-mapping": "^2.10.10",
+        "baseline-browser-mapping": "^2.10.29",
         "raw-loader": "^4.0.2",
       },
     },
@@ -28,13 +29,13 @@
   "packages": {
     "@algolia/abtesting": ["@algolia/abtesting@1.3.0", "", { "dependencies": { "@algolia/client-common": "5.37.0", "@algolia/requester-browser-xhr": "5.37.0", "@algolia/requester-fetch": "5.37.0", "@algolia/requester-node-http": "5.37.0" } }, "sha512-KqPVLdVNfoJzX5BKNGM9bsW8saHeyax8kmPFXul5gejrSPN3qss7PgsFH5mMem7oR8tvjvNkia97ljEYPYCN8Q=="],
 
-    "@algolia/autocomplete-core": ["@algolia/autocomplete-core@1.17.9", "", { "dependencies": { "@algolia/autocomplete-plugin-algolia-insights": "1.17.9", "@algolia/autocomplete-shared": "1.17.9" } }, "sha512-O7BxrpLDPJWWHv/DLA9DRFWs+iY1uOJZkqUwjS5HSZAGcl0hIVCQ97LTLewiZmZ402JYUrun+8NqFP+hCknlbQ=="],
+    "@algolia/autocomplete-core": ["@algolia/autocomplete-core@1.19.8", "", { "dependencies": { "@algolia/autocomplete-plugin-algolia-insights": "1.19.8", "@algolia/autocomplete-shared": "1.19.8" } }, "sha512-3YEorYg44niXcm7gkft3nXYItHd44e8tmh4D33CTszPgP0QWkaLEaFywiNyJBo7UL/mqObA/G9RYuU7R8tN1IA=="],
 
-    "@algolia/autocomplete-plugin-algolia-insights": ["@algolia/autocomplete-plugin-algolia-insights@1.17.9", "", { "dependencies": { "@algolia/autocomplete-shared": "1.17.9" }, "peerDependencies": { "search-insights": ">= 1 < 3" } }, "sha512-u1fEHkCbWF92DBeB/KHeMacsjsoI0wFhjZtlCq2ddZbAehshbZST6Hs0Avkc0s+4UyBGbMDnSuXHLuvRWK5iDQ=="],
+    "@algolia/autocomplete-plugin-algolia-insights": ["@algolia/autocomplete-plugin-algolia-insights@1.19.8", "", { "dependencies": { "@algolia/autocomplete-shared": "1.19.8" }, "peerDependencies": { "search-insights": ">= 1 < 3" } }, "sha512-ZvJWO8ZZJDpc1LNM2TTBdmQsZBLMR4rU5iNR2OYvEeFBiaf/0ESnRSSLQbryarJY4SVxtoz6A2ZtDMNM+iQEAA=="],
 
     "@algolia/autocomplete-preset-algolia": ["@algolia/autocomplete-preset-algolia@1.17.9", "", { "dependencies": { "@algolia/autocomplete-shared": "1.17.9" }, "peerDependencies": { "@algolia/client-search": ">= 4.9.1 < 6", "algoliasearch": ">= 4.9.1 < 6" } }, "sha512-Na1OuceSJeg8j7ZWn5ssMu/Ax3amtOwk76u4h5J4eK2Nx2KB5qt0Z4cOapCsxot9VcEN11ADV5aUSlQF4RhGjQ=="],
 
-    "@algolia/autocomplete-shared": ["@algolia/autocomplete-shared@1.17.9", "", { "peerDependencies": { "@algolia/client-search": ">= 4.9.1 < 6", "algoliasearch": ">= 4.9.1 < 6" } }, "sha512-iDf05JDQ7I0b7JEA/9IektxN/80a2MZ1ToohfmNS3rfeuQnIKI3IJlIafD0xu4StbtQTghx9T3Maa97ytkXenQ=="],
+    "@algolia/autocomplete-shared": ["@algolia/autocomplete-shared@1.19.8", "", { "peerDependencies": { "@algolia/client-search": ">= 4.9.1 < 6", "algoliasearch": ">= 4.9.1 < 6" } }, "sha512-h5hf2t8ejF6vlOgvLaZzQbWs5SyH2z4PAWygNAvvD/2RI29hdQ54ldUGwqVuj9Srs+n8XUKTPUqb7fvhBhQrnQ=="],
 
     "@algolia/client-abtesting": ["@algolia/client-abtesting@5.37.0", "", { "dependencies": { "@algolia/client-common": "5.37.0", "@algolia/requester-browser-xhr": "5.37.0", "@algolia/requester-fetch": "5.37.0", "@algolia/requester-node-http": "5.37.0" } }, "sha512-Dp2Zq+x9qQFnuiQhVe91EeaaPxWBhzwQ6QnznZQnH9C1/ei3dvtmAFfFeaTxM6FzfJXDLvVnaQagTYFTQz3R5g=="],
 
@@ -314,8 +315,6 @@
 
     "@babel/runtime": ["@babel/runtime@7.28.4", "", {}, "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="],
 
-    "@babel/runtime-corejs3": ["@babel/runtime-corejs3@7.28.4", "", { "dependencies": { "core-js-pure": "^3.43.0" } }, "sha512-h7iEYiW4HebClDEhtvFObtPmIvrd1SSfpI9EhOeKk4CtIK/ngBWFpuhCzhdmRKtg71ylcue+9I6dv54XYO1epQ=="],
-
     "@babel/template": ["@babel/template@7.27.2", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/parser": "^7.27.2", "@babel/types": "^7.27.1" } }, "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw=="],
 
     "@babel/traverse": ["@babel/traverse@7.28.4", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.3", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.4", "@babel/template": "^7.27.2", "@babel/types": "^7.28.4", "debug": "^4.3.1" } }, "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ=="],
@@ -424,59 +423,59 @@
 
     "@docsearch/react": ["@docsearch/react@3.9.0", "", { "dependencies": { "@algolia/autocomplete-core": "1.17.9", "@algolia/autocomplete-preset-algolia": "1.17.9", "@docsearch/css": "3.9.0", "algoliasearch": "^5.14.2" }, "peerDependencies": { "@types/react": ">= 16.8.0 < 20.0.0", "react": ">= 16.8.0 < 20.0.0", "react-dom": ">= 16.8.0 < 20.0.0", "search-insights": ">= 1 < 3" }, "optionalPeers": ["@types/react", "react", "react-dom", "search-insights"] }, "sha512-mb5FOZYZIkRQ6s/NWnM98k879vu5pscWqTLubLFBO87igYYT4VzVazh4h5o/zCvTIZgEt3PvsCOMOswOUo9yHQ=="],
 
-    "@docusaurus/babel": ["@docusaurus/babel@3.9.2", "", { "dependencies": { "@babel/core": "^7.25.9", "@babel/generator": "^7.25.9", "@babel/plugin-syntax-dynamic-import": "^7.8.3", "@babel/plugin-transform-runtime": "^7.25.9", "@babel/preset-env": "^7.25.9", "@babel/preset-react": "^7.25.9", "@babel/preset-typescript": "^7.25.9", "@babel/runtime": "^7.25.9", "@babel/runtime-corejs3": "^7.25.9", "@babel/traverse": "^7.25.9", "@docusaurus/logger": "3.9.2", "@docusaurus/utils": "3.9.2", "babel-plugin-dynamic-import-node": "^2.3.3", "fs-extra": "^11.1.1", "tslib": "^2.6.0" } }, "sha512-GEANdi/SgER+L7Japs25YiGil/AUDnFFHaCGPBbundxoWtCkA2lmy7/tFmgED4y1htAy6Oi4wkJEQdGssnw9MA=="],
+    "@docusaurus/babel": ["@docusaurus/babel@3.10.1", "", { "dependencies": { "@babel/core": "^7.25.9", "@babel/generator": "^7.25.9", "@babel/plugin-syntax-dynamic-import": "^7.8.3", "@babel/plugin-transform-runtime": "^7.25.9", "@babel/preset-env": "^7.25.9", "@babel/preset-react": "^7.25.9", "@babel/preset-typescript": "^7.25.9", "@babel/runtime": "^7.25.9", "@babel/traverse": "^7.25.9", "@docusaurus/logger": "3.10.1", "@docusaurus/utils": "3.10.1", "babel-plugin-dynamic-import-node": "^2.3.3", "fs-extra": "^11.1.1", "tslib": "^2.6.0" } }, "sha512-DZzFO1K3v/GoEt1fx1DiYHF4en+PuhtQf1AkQJa5zu3CoeKSpr5cpQRUlz3jr0m44wyzmSXu9bVpfir+N4+8bg=="],
 
-    "@docusaurus/bundler": ["@docusaurus/bundler@3.9.2", "", { "dependencies": { "@babel/core": "^7.25.9", "@docusaurus/babel": "3.9.2", "@docusaurus/cssnano-preset": "3.9.2", "@docusaurus/logger": "3.9.2", "@docusaurus/types": "3.9.2", "@docusaurus/utils": "3.9.2", "babel-loader": "^9.2.1", "clean-css": "^5.3.3", "copy-webpack-plugin": "^11.0.0", "css-loader": "^6.11.0", "css-minimizer-webpack-plugin": "^5.0.1", "cssnano": "^6.1.2", "file-loader": "^6.2.0", "html-minifier-terser": "^7.2.0", "mini-css-extract-plugin": "^2.9.2", "null-loader": "^4.0.1", "postcss": "^8.5.4", "postcss-loader": "^7.3.4", "postcss-preset-env": "^10.2.1", "terser-webpack-plugin": "^5.3.9", "tslib": "^2.6.0", "url-loader": "^4.1.1", "webpack": "^5.95.0", "webpackbar": "^6.0.1" }, "peerDependencies": { "@docusaurus/faster": "*" }, "optionalPeers": ["@docusaurus/faster"] }, "sha512-ZOVi6GYgTcsZcUzjblpzk3wH1Fya2VNpd5jtHoCCFcJlMQ1EYXZetfAnRHLcyiFeBABaI1ltTYbOBtH/gahGVA=="],
+    "@docusaurus/bundler": ["@docusaurus/bundler@3.10.1", "", { "dependencies": { "@babel/core": "^7.25.9", "@docusaurus/babel": "3.10.1", "@docusaurus/cssnano-preset": "3.10.1", "@docusaurus/logger": "3.10.1", "@docusaurus/types": "3.10.1", "@docusaurus/utils": "3.10.1", "babel-loader": "^9.2.1", "clean-css": "^5.3.3", "copy-webpack-plugin": "^11.0.0", "css-loader": "^6.11.0", "css-minimizer-webpack-plugin": "^5.0.1", "cssnano": "^6.1.2", "file-loader": "^6.2.0", "html-minifier-terser": "^7.2.0", "mini-css-extract-plugin": "^2.9.2", "null-loader": "^4.0.1", "postcss": "^8.5.4", "postcss-loader": "^7.3.4", "postcss-preset-env": "^10.2.1", "terser-webpack-plugin": "^5.3.9", "tslib": "^2.6.0", "url-loader": "^4.1.1", "webpack": "^5.95.0", "webpackbar": "^7.0.0" }, "peerDependencies": { "@docusaurus/faster": "*" }, "optionalPeers": ["@docusaurus/faster"] }, "sha512-HIqQPvbqnnQRe4NsBd1774KRarjXqS6wHsWELtyuSs1gCfvixJO2jUGH/OEBtr1Gvzpw+ze5CjGMvSJ8UE1KUw=="],
 
-    "@docusaurus/core": ["@docusaurus/core@3.9.2", "", { "dependencies": { "@docusaurus/babel": "3.9.2", "@docusaurus/bundler": "3.9.2", "@docusaurus/logger": "3.9.2", "@docusaurus/mdx-loader": "3.9.2", "@docusaurus/utils": "3.9.2", "@docusaurus/utils-common": "3.9.2", "@docusaurus/utils-validation": "3.9.2", "boxen": "^6.2.1", "chalk": "^4.1.2", "chokidar": "^3.5.3", "cli-table3": "^0.6.3", "combine-promises": "^1.1.0", "commander": "^5.1.0", "core-js": "^3.31.1", "detect-port": "^1.5.1", "escape-html": "^1.0.3", "eta": "^2.2.0", "eval": "^0.1.8", "execa": "5.1.1", "fs-extra": "^11.1.1", "html-tags": "^3.3.1", "html-webpack-plugin": "^5.6.0", "leven": "^3.1.0", "lodash": "^4.17.21", "open": "^8.4.0", "p-map": "^4.0.0", "prompts": "^2.4.2", "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0", "react-loadable": "npm:@docusaurus/react-loadable@6.0.0", "react-loadable-ssr-addon-v5-slorber": "^1.0.1", "react-router": "^5.3.4", "react-router-config": "^5.1.1", "react-router-dom": "^5.3.4", "semver": "^7.5.4", "serve-handler": "^6.1.6", "tinypool": "^1.0.2", "tslib": "^2.6.0", "update-notifier": "^6.0.2", "webpack": "^5.95.0", "webpack-bundle-analyzer": "^4.10.2", "webpack-dev-server": "^5.2.2", "webpack-merge": "^6.0.1" }, "peerDependencies": { "@mdx-js/react": "^3.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "bin": { "docusaurus": "bin/docusaurus.mjs" } }, "sha512-HbjwKeC+pHUFBfLMNzuSjqFE/58+rLVKmOU3lxQrpsxLBOGosYco/Q0GduBb0/jEMRiyEqjNT/01rRdOMWq5pw=="],
+    "@docusaurus/core": ["@docusaurus/core@3.10.1", "", { "dependencies": { "@docusaurus/babel": "3.10.1", "@docusaurus/bundler": "3.10.1", "@docusaurus/logger": "3.10.1", "@docusaurus/mdx-loader": "3.10.1", "@docusaurus/utils": "3.10.1", "@docusaurus/utils-common": "3.10.1", "@docusaurus/utils-validation": "3.10.1", "boxen": "^6.2.1", "chalk": "^4.1.2", "chokidar": "^3.5.3", "cli-table3": "^0.6.3", "combine-promises": "^1.1.0", "commander": "^5.1.0", "core-js": "^3.31.1", "detect-port": "^1.5.1", "escape-html": "^1.0.3", "eta": "^2.2.0", "eval": "^0.1.8", "execa": "^5.1.1", "fs-extra": "^11.1.1", "html-tags": "^3.3.1", "html-webpack-plugin": "^5.6.0", "leven": "^3.1.0", "lodash": "^4.17.21", "open": "^8.4.0", "p-map": "^4.0.0", "prompts": "^2.4.2", "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0", "react-loadable": "npm:@docusaurus/react-loadable@6.0.0", "react-loadable-ssr-addon-v5-slorber": "^1.0.3", "react-router": "^5.3.4", "react-router-config": "^5.1.1", "react-router-dom": "^5.3.4", "semver": "^7.5.4", "serve-handler": "^6.1.7", "tinypool": "^1.0.2", "tslib": "^2.6.0", "update-notifier": "^6.0.2", "webpack": "^5.95.0", "webpack-bundle-analyzer": "^4.10.2", "webpack-dev-server": "^5.2.2", "webpack-merge": "^6.0.1" }, "peerDependencies": { "@docusaurus/faster": "*", "@mdx-js/react": "^3.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@docusaurus/faster"], "bin": { "docusaurus": "bin/docusaurus.mjs" } }, "sha512-3pf2fXXw0eVk8WnC3T4LIigRDupcpvngpKo9Vy7mYyBhuddc0klDUuZAIfzMoK6z05pdlk6EFC/vBSX43+1O5w=="],
 
-    "@docusaurus/cssnano-preset": ["@docusaurus/cssnano-preset@3.9.2", "", { "dependencies": { "cssnano-preset-advanced": "^6.1.2", "postcss": "^8.5.4", "postcss-sort-media-queries": "^5.2.0", "tslib": "^2.6.0" } }, "sha512-8gBKup94aGttRduABsj7bpPFTX7kbwu+xh3K9NMCF5K4bWBqTFYW+REKHF6iBVDHRJ4grZdIPbvkiHd/XNKRMQ=="],
+    "@docusaurus/cssnano-preset": ["@docusaurus/cssnano-preset@3.10.1", "", { "dependencies": { "cssnano-preset-advanced": "^6.1.2", "postcss": "^8.5.4", "postcss-sort-media-queries": "^5.2.0", "tslib": "^2.6.0" } }, "sha512-eNfHGcTKCSq6xmcavAkX3RRclHaE2xRCMParlDXLdXVP01/a2e/jKXMj/0ULnLFQSNwwuI62L0Ge8J+nZsR7UQ=="],
 
-    "@docusaurus/logger": ["@docusaurus/logger@3.9.2", "", { "dependencies": { "chalk": "^4.1.2", "tslib": "^2.6.0" } }, "sha512-/SVCc57ByARzGSU60c50rMyQlBuMIJCjcsJlkphxY6B0GV4UH3tcA1994N8fFfbJ9kX3jIBe/xg3XP5qBtGDbA=="],
+    "@docusaurus/logger": ["@docusaurus/logger@3.10.1", "", { "dependencies": { "chalk": "^4.1.2", "tslib": "^2.6.0" } }, "sha512-oPjNFnfJsRCkePVjkGrxWGq4MvJKRQT0r9jOP0eRBTZ7Wr9FAbzdP/Gjs0I2Ss6YRkPoEgygKG112OkE6skvJw=="],
 
-    "@docusaurus/mdx-loader": ["@docusaurus/mdx-loader@3.9.2", "", { "dependencies": { "@docusaurus/logger": "3.9.2", "@docusaurus/utils": "3.9.2", "@docusaurus/utils-validation": "3.9.2", "@mdx-js/mdx": "^3.0.0", "@slorber/remark-comment": "^1.0.0", "escape-html": "^1.0.3", "estree-util-value-to-estree": "^3.0.1", "file-loader": "^6.2.0", "fs-extra": "^11.1.1", "image-size": "^2.0.2", "mdast-util-mdx": "^3.0.0", "mdast-util-to-string": "^4.0.0", "rehype-raw": "^7.0.0", "remark-directive": "^3.0.0", "remark-emoji": "^4.0.0", "remark-frontmatter": "^5.0.0", "remark-gfm": "^4.0.0", "stringify-object": "^3.3.0", "tslib": "^2.6.0", "unified": "^11.0.3", "unist-util-visit": "^5.0.0", "url-loader": "^4.1.1", "vfile": "^6.0.1", "webpack": "^5.88.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-wiYoGwF9gdd6rev62xDU8AAM8JuLI/hlwOtCzMmYcspEkzecKrP8J8X+KpYnTlACBUUtXNJpSoCwFWJhLRevzQ=="],
+    "@docusaurus/mdx-loader": ["@docusaurus/mdx-loader@3.10.1", "", { "dependencies": { "@docusaurus/logger": "3.10.1", "@docusaurus/utils": "3.10.1", "@docusaurus/utils-validation": "3.10.1", "@mdx-js/mdx": "^3.0.0", "@slorber/remark-comment": "^1.0.0", "escape-html": "^1.0.3", "estree-util-value-to-estree": "^3.0.1", "file-loader": "^6.2.0", "fs-extra": "^11.1.1", "image-size": "^2.0.2", "mdast-util-mdx": "^3.0.0", "mdast-util-to-string": "^4.0.0", "rehype-raw": "^7.0.0", "remark-directive": "^3.0.0", "remark-emoji": "^4.0.0", "remark-frontmatter": "^5.0.0", "remark-gfm": "^4.0.0", "stringify-object": "^3.3.0", "tslib": "^2.6.0", "unified": "^11.0.3", "unist-util-visit": "^5.0.0", "url-loader": "^4.1.1", "vfile": "^6.0.1", "webpack": "^5.88.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-GRmeb/wQ+iXRrFwcHBfgQhrJxGElgCsoTWZYDhccjsZVne1p8MK/EpQVIloXttz76TCe78kKD5AEG9n1xc1oxQ=="],
 
-    "@docusaurus/module-type-aliases": ["@docusaurus/module-type-aliases@3.9.2", "", { "dependencies": { "@docusaurus/types": "3.9.2", "@types/history": "^4.7.11", "@types/react": "*", "@types/react-router-config": "*", "@types/react-router-dom": "*", "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0", "react-loadable": "npm:@docusaurus/react-loadable@6.0.0" }, "peerDependencies": { "react": "*", "react-dom": "*" } }, "sha512-8qVe2QA9hVLzvnxP46ysuofJUIc/yYQ82tvA/rBTrnpXtCjNSFLxEZfd5U8cYZuJIVlkPxamsIgwd5tGZXfvew=="],
+    "@docusaurus/module-type-aliases": ["@docusaurus/module-type-aliases@3.10.1", "", { "dependencies": { "@docusaurus/types": "3.10.1", "@types/history": "^4.7.11", "@types/react": "*", "@types/react-router-config": "*", "@types/react-router-dom": "*", "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0", "react-loadable": "npm:@docusaurus/react-loadable@6.0.0" }, "peerDependencies": { "react": "*", "react-dom": "*" } }, "sha512-YoOZKUdGlp8xSYhuAkGdSo5Ydkbq4V4eK3sD8v0a2hloxCWdQbNBhkc+Ko9QyjpESc0BYcIGM5iHVAy5hdFV6w=="],
 
-    "@docusaurus/plugin-content-blog": ["@docusaurus/plugin-content-blog@3.9.2", "", { "dependencies": { "@docusaurus/core": "3.9.2", "@docusaurus/logger": "3.9.2", "@docusaurus/mdx-loader": "3.9.2", "@docusaurus/theme-common": "3.9.2", "@docusaurus/types": "3.9.2", "@docusaurus/utils": "3.9.2", "@docusaurus/utils-common": "3.9.2", "@docusaurus/utils-validation": "3.9.2", "cheerio": "1.0.0-rc.12", "feed": "^4.2.2", "fs-extra": "^11.1.1", "lodash": "^4.17.21", "schema-dts": "^1.1.2", "srcset": "^4.0.0", "tslib": "^2.6.0", "unist-util-visit": "^5.0.0", "utility-types": "^3.10.0", "webpack": "^5.88.1" }, "peerDependencies": { "@docusaurus/plugin-content-docs": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-3I2HXy3L1QcjLJLGAoTvoBnpOwa6DPUa3Q0dMK19UTY9mhPkKQg/DYhAGTiBUKcTR0f08iw7kLPqOhIgdV3eVQ=="],
+    "@docusaurus/plugin-content-blog": ["@docusaurus/plugin-content-blog@3.10.1", "", { "dependencies": { "@docusaurus/core": "3.10.1", "@docusaurus/logger": "3.10.1", "@docusaurus/mdx-loader": "3.10.1", "@docusaurus/theme-common": "3.10.1", "@docusaurus/types": "3.10.1", "@docusaurus/utils": "3.10.1", "@docusaurus/utils-common": "3.10.1", "@docusaurus/utils-validation": "3.10.1", "cheerio": "1.0.0-rc.12", "combine-promises": "^1.1.0", "feed": "^4.2.2", "fs-extra": "^11.1.1", "lodash": "^4.17.21", "schema-dts": "^1.1.2", "srcset": "^4.0.0", "tslib": "^2.6.0", "unist-util-visit": "^5.0.0", "utility-types": "^3.10.0", "webpack": "^5.88.1" }, "peerDependencies": { "@docusaurus/plugin-content-docs": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-mmkgE6Q2+K74tnkou7tXlpDLvoCU/qkSa2GSQ3XUiHWvcebCoDQzS670RR3tO8PmaWlIyWWISYWzZLuMfxunRA=="],
 
-    "@docusaurus/plugin-content-docs": ["@docusaurus/plugin-content-docs@3.9.2", "", { "dependencies": { "@docusaurus/core": "3.9.2", "@docusaurus/logger": "3.9.2", "@docusaurus/mdx-loader": "3.9.2", "@docusaurus/module-type-aliases": "3.9.2", "@docusaurus/theme-common": "3.9.2", "@docusaurus/types": "3.9.2", "@docusaurus/utils": "3.9.2", "@docusaurus/utils-common": "3.9.2", "@docusaurus/utils-validation": "3.9.2", "@types/react-router-config": "^5.0.7", "combine-promises": "^1.1.0", "fs-extra": "^11.1.1", "js-yaml": "^4.1.0", "lodash": "^4.17.21", "schema-dts": "^1.1.2", "tslib": "^2.6.0", "utility-types": "^3.10.0", "webpack": "^5.88.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg=="],
+    "@docusaurus/plugin-content-docs": ["@docusaurus/plugin-content-docs@3.10.1", "", { "dependencies": { "@docusaurus/core": "3.10.1", "@docusaurus/logger": "3.10.1", "@docusaurus/mdx-loader": "3.10.1", "@docusaurus/module-type-aliases": "3.10.1", "@docusaurus/theme-common": "3.10.1", "@docusaurus/types": "3.10.1", "@docusaurus/utils": "3.10.1", "@docusaurus/utils-common": "3.10.1", "@docusaurus/utils-validation": "3.10.1", "@types/react-router-config": "^5.0.7", "combine-promises": "^1.1.0", "fs-extra": "^11.1.1", "js-yaml": "^4.1.0", "lodash": "^4.17.21", "schema-dts": "^1.1.2", "tslib": "^2.6.0", "utility-types": "^3.10.0", "webpack": "^5.88.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-2jRVrtzjf8LClGTHQlwlwuD3wQXRx3WEoF7XUarJ8Ou+0onV+SLtejsyfY9JLpfUh9hPhXM4pbBGkyAY4Bi3HQ=="],
 
-    "@docusaurus/plugin-content-pages": ["@docusaurus/plugin-content-pages@3.9.2", "", { "dependencies": { "@docusaurus/core": "3.9.2", "@docusaurus/mdx-loader": "3.9.2", "@docusaurus/types": "3.9.2", "@docusaurus/utils": "3.9.2", "@docusaurus/utils-validation": "3.9.2", "fs-extra": "^11.1.1", "tslib": "^2.6.0", "webpack": "^5.88.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-s4849w/p4noXUrGpPUF0BPqIAfdAe76BLaRGAGKZ1gTDNiGxGcpsLcwJ9OTi1/V8A+AzvsmI9pkjie2zjIQZKA=="],
+    "@docusaurus/plugin-content-pages": ["@docusaurus/plugin-content-pages@3.10.1", "", { "dependencies": { "@docusaurus/core": "3.10.1", "@docusaurus/mdx-loader": "3.10.1", "@docusaurus/types": "3.10.1", "@docusaurus/utils": "3.10.1", "@docusaurus/utils-validation": "3.10.1", "fs-extra": "^11.1.1", "tslib": "^2.6.0", "webpack": "^5.88.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-huJpaRPMl42nsFwuCXvV8bVDj2MazuwRJIUylI/RSlmZeJssVoZXeCjVf1y+1Drtpa9SKcdGn8yoJ76IRJijtw=="],
 
-    "@docusaurus/plugin-css-cascade-layers": ["@docusaurus/plugin-css-cascade-layers@3.9.2", "", { "dependencies": { "@docusaurus/core": "3.9.2", "@docusaurus/types": "3.9.2", "@docusaurus/utils": "3.9.2", "@docusaurus/utils-validation": "3.9.2", "tslib": "^2.6.0" } }, "sha512-w1s3+Ss+eOQbscGM4cfIFBlVg/QKxyYgj26k5AnakuHkKxH6004ZtuLe5awMBotIYF2bbGDoDhpgQ4r/kcj4rQ=="],
+    "@docusaurus/plugin-css-cascade-layers": ["@docusaurus/plugin-css-cascade-layers@3.10.1", "", { "dependencies": { "@docusaurus/core": "3.10.1", "@docusaurus/types": "3.10.1", "@docusaurus/utils": "3.10.1", "@docusaurus/utils-validation": "3.10.1", "tslib": "^2.6.0" } }, "sha512-r//fn+MNHkE1wCof8T29VAQezt1enGCpsFxoziBbvLgBM4JfXN2P3rxrBaavHmvLvm7lYkpJeitcDthwnmWCTw=="],
 
-    "@docusaurus/plugin-debug": ["@docusaurus/plugin-debug@3.9.2", "", { "dependencies": { "@docusaurus/core": "3.9.2", "@docusaurus/types": "3.9.2", "@docusaurus/utils": "3.9.2", "fs-extra": "^11.1.1", "react-json-view-lite": "^2.3.0", "tslib": "^2.6.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-j7a5hWuAFxyQAkilZwhsQ/b3T7FfHZ+0dub6j/GxKNFJp2h9qk/P1Bp7vrGASnvA9KNQBBL1ZXTe7jlh4VdPdA=="],
+    "@docusaurus/plugin-debug": ["@docusaurus/plugin-debug@3.10.1", "", { "dependencies": { "@docusaurus/core": "3.10.1", "@docusaurus/types": "3.10.1", "@docusaurus/utils": "3.10.1", "fs-extra": "^11.1.1", "react-json-view-lite": "^2.3.0", "tslib": "^2.6.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-9KqOpKNfAyqGZykRb9LhIT/vyRF6sm/ykhjj/39JvaJahDS+jZJE0Z1Wfz9q3DUNDTMNN0Q7u/kk4rKKU+IJuA=="],
 
-    "@docusaurus/plugin-google-analytics": ["@docusaurus/plugin-google-analytics@3.9.2", "", { "dependencies": { "@docusaurus/core": "3.9.2", "@docusaurus/types": "3.9.2", "@docusaurus/utils-validation": "3.9.2", "tslib": "^2.6.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-mAwwQJ1Us9jL/lVjXtErXto4p4/iaLlweC54yDUK1a97WfkC6Z2k5/769JsFgwOwOP+n5mUQGACXOEQ0XDuVUw=="],
+    "@docusaurus/plugin-google-analytics": ["@docusaurus/plugin-google-analytics@3.10.1", "", { "dependencies": { "@docusaurus/core": "3.10.1", "@docusaurus/types": "3.10.1", "@docusaurus/utils-validation": "3.10.1", "tslib": "^2.6.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-8o0P1KtmgdYQHH+oInitPpRWI0Of5XednAX4+DMhQNSmGSRNrsEEHg1ebv35m9AgRClfAytCJ5jA9KvcASTyuA=="],
 
-    "@docusaurus/plugin-google-gtag": ["@docusaurus/plugin-google-gtag@3.9.2", "", { "dependencies": { "@docusaurus/core": "3.9.2", "@docusaurus/types": "3.9.2", "@docusaurus/utils-validation": "3.9.2", "@types/gtag.js": "^0.0.12", "tslib": "^2.6.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-YJ4lDCphabBtw19ooSlc1MnxtYGpjFV9rEdzjLsUnBCeis2djUyCozZaFhCg6NGEwOn7HDDyMh0yzcdRpnuIvA=="],
+    "@docusaurus/plugin-google-gtag": ["@docusaurus/plugin-google-gtag@3.10.1", "", { "dependencies": { "@docusaurus/core": "3.10.1", "@docusaurus/types": "3.10.1", "@docusaurus/utils-validation": "3.10.1", "@types/gtag.js": "^0.0.20", "tslib": "^2.6.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-pu3xIUo5o/zCMLfUY9BO5KOwSH0zIsAGyFRPvXHayFSA5XIhCU/SFuB0g0ZNjFn9niZLCaNvoeAuOGFJZq0fdw=="],
 
-    "@docusaurus/plugin-google-tag-manager": ["@docusaurus/plugin-google-tag-manager@3.9.2", "", { "dependencies": { "@docusaurus/core": "3.9.2", "@docusaurus/types": "3.9.2", "@docusaurus/utils-validation": "3.9.2", "tslib": "^2.6.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-LJtIrkZN/tuHD8NqDAW1Tnw0ekOwRTfobWPsdO15YxcicBo2ykKF0/D6n0vVBfd3srwr9Z6rzrIWYrMzBGrvNw=="],
+    "@docusaurus/plugin-google-tag-manager": ["@docusaurus/plugin-google-tag-manager@3.10.1", "", { "dependencies": { "@docusaurus/core": "3.10.1", "@docusaurus/types": "3.10.1", "@docusaurus/utils-validation": "3.10.1", "tslib": "^2.6.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-f6fyGHiCm7kJHBtAisGQS5oNBnpnMTYQZxDXeVrnw/3zWU+LMA22pr6UHGYkBKDbN+qPC5QHG3NuOfzQLq3+Lw=="],
 
-    "@docusaurus/plugin-sitemap": ["@docusaurus/plugin-sitemap@3.9.2", "", { "dependencies": { "@docusaurus/core": "3.9.2", "@docusaurus/logger": "3.9.2", "@docusaurus/types": "3.9.2", "@docusaurus/utils": "3.9.2", "@docusaurus/utils-common": "3.9.2", "@docusaurus/utils-validation": "3.9.2", "fs-extra": "^11.1.1", "sitemap": "^7.1.1", "tslib": "^2.6.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-WLh7ymgDXjG8oPoM/T4/zUP7KcSuFYRZAUTl8vR6VzYkfc18GBM4xLhcT+AKOwun6kBivYKUJf+vlqYJkm+RHw=="],
+    "@docusaurus/plugin-sitemap": ["@docusaurus/plugin-sitemap@3.10.1", "", { "dependencies": { "@docusaurus/core": "3.10.1", "@docusaurus/logger": "3.10.1", "@docusaurus/types": "3.10.1", "@docusaurus/utils": "3.10.1", "@docusaurus/utils-common": "3.10.1", "@docusaurus/utils-validation": "3.10.1", "fs-extra": "^11.1.1", "sitemap": "^7.1.1", "tslib": "^2.6.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-C26MbmmqgdjkDq1htaZ3aD7LzEDKFWXfpyQpt0EOUThuq5nV77zDaedV20yHcVo9p+3ey9aZ4pbHA0D3QcZTzg=="],
 
-    "@docusaurus/plugin-svgr": ["@docusaurus/plugin-svgr@3.9.2", "", { "dependencies": { "@docusaurus/core": "3.9.2", "@docusaurus/types": "3.9.2", "@docusaurus/utils": "3.9.2", "@docusaurus/utils-validation": "3.9.2", "@svgr/core": "8.1.0", "@svgr/webpack": "^8.1.0", "tslib": "^2.6.0", "webpack": "^5.88.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-n+1DE+5b3Lnf27TgVU5jM1d4x5tUh2oW5LTsBxJX4PsAPV0JGcmI6p3yLYtEY0LRVEIJh+8RsdQmRE66wSV8mw=="],
+    "@docusaurus/plugin-svgr": ["@docusaurus/plugin-svgr@3.10.1", "", { "dependencies": { "@docusaurus/core": "3.10.1", "@docusaurus/types": "3.10.1", "@docusaurus/utils": "3.10.1", "@docusaurus/utils-validation": "3.10.1", "@svgr/core": "8.1.0", "@svgr/webpack": "^8.1.0", "tslib": "^2.6.0", "webpack": "^5.88.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-6SFxsmjWFkVLDmBUvFK6i72QjUwqyQFe4Ovz+SUJophJjOyVG3ZZG5IQpBC/kX/Gfv1yWeU9nWauH6F6Q7QX/Q=="],
 
-    "@docusaurus/preset-classic": ["@docusaurus/preset-classic@3.9.2", "", { "dependencies": { "@docusaurus/core": "3.9.2", "@docusaurus/plugin-content-blog": "3.9.2", "@docusaurus/plugin-content-docs": "3.9.2", "@docusaurus/plugin-content-pages": "3.9.2", "@docusaurus/plugin-css-cascade-layers": "3.9.2", "@docusaurus/plugin-debug": "3.9.2", "@docusaurus/plugin-google-analytics": "3.9.2", "@docusaurus/plugin-google-gtag": "3.9.2", "@docusaurus/plugin-google-tag-manager": "3.9.2", "@docusaurus/plugin-sitemap": "3.9.2", "@docusaurus/plugin-svgr": "3.9.2", "@docusaurus/theme-classic": "3.9.2", "@docusaurus/theme-common": "3.9.2", "@docusaurus/theme-search-algolia": "3.9.2", "@docusaurus/types": "3.9.2" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-IgyYO2Gvaigi21LuDIe+nvmN/dfGXAiMcV/murFqcpjnZc7jxFAxW+9LEjdPt61uZLxG4ByW/oUmX/DDK9t/8w=="],
+    "@docusaurus/preset-classic": ["@docusaurus/preset-classic@3.10.1", "", { "dependencies": { "@docusaurus/core": "3.10.1", "@docusaurus/plugin-content-blog": "3.10.1", "@docusaurus/plugin-content-docs": "3.10.1", "@docusaurus/plugin-content-pages": "3.10.1", "@docusaurus/plugin-css-cascade-layers": "3.10.1", "@docusaurus/plugin-debug": "3.10.1", "@docusaurus/plugin-google-analytics": "3.10.1", "@docusaurus/plugin-google-gtag": "3.10.1", "@docusaurus/plugin-google-tag-manager": "3.10.1", "@docusaurus/plugin-sitemap": "3.10.1", "@docusaurus/plugin-svgr": "3.10.1", "@docusaurus/theme-classic": "3.10.1", "@docusaurus/theme-common": "3.10.1", "@docusaurus/theme-search-algolia": "3.10.1", "@docusaurus/types": "3.10.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-YO/FL8v1zmbxoTso6mjMz/RDjhaTJxb1UpFFTDdY5847LLDCeyYiYlrhyTbgN1RIN3xnkLKZ9Lj1x8hUzI4JOg=="],
 
-    "@docusaurus/theme-classic": ["@docusaurus/theme-classic@3.9.2", "", { "dependencies": { "@docusaurus/core": "3.9.2", "@docusaurus/logger": "3.9.2", "@docusaurus/mdx-loader": "3.9.2", "@docusaurus/module-type-aliases": "3.9.2", "@docusaurus/plugin-content-blog": "3.9.2", "@docusaurus/plugin-content-docs": "3.9.2", "@docusaurus/plugin-content-pages": "3.9.2", "@docusaurus/theme-common": "3.9.2", "@docusaurus/theme-translations": "3.9.2", "@docusaurus/types": "3.9.2", "@docusaurus/utils": "3.9.2", "@docusaurus/utils-common": "3.9.2", "@docusaurus/utils-validation": "3.9.2", "@mdx-js/react": "^3.0.0", "clsx": "^2.0.0", "infima": "0.2.0-alpha.45", "lodash": "^4.17.21", "nprogress": "^0.2.0", "postcss": "^8.5.4", "prism-react-renderer": "^2.3.0", "prismjs": "^1.29.0", "react-router-dom": "^5.3.4", "rtlcss": "^4.1.0", "tslib": "^2.6.0", "utility-types": "^3.10.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-IGUsArG5hhekXd7RDb11v94ycpJpFdJPkLnt10fFQWOVxAtq5/D7hT6lzc2fhyQKaaCE62qVajOMKL7OiAFAIA=="],
+    "@docusaurus/theme-classic": ["@docusaurus/theme-classic@3.10.1", "", { "dependencies": { "@docusaurus/core": "3.10.1", "@docusaurus/logger": "3.10.1", "@docusaurus/mdx-loader": "3.10.1", "@docusaurus/module-type-aliases": "3.10.1", "@docusaurus/plugin-content-blog": "3.10.1", "@docusaurus/plugin-content-docs": "3.10.1", "@docusaurus/plugin-content-pages": "3.10.1", "@docusaurus/theme-common": "3.10.1", "@docusaurus/theme-translations": "3.10.1", "@docusaurus/types": "3.10.1", "@docusaurus/utils": "3.10.1", "@docusaurus/utils-common": "3.10.1", "@docusaurus/utils-validation": "3.10.1", "@mdx-js/react": "^3.0.0", "clsx": "^2.0.0", "copy-text-to-clipboard": "^3.2.0", "infima": "0.2.0-alpha.45", "lodash": "^4.17.21", "nprogress": "^0.2.0", "postcss": "^8.5.4", "prism-react-renderer": "^2.3.0", "prismjs": "^1.29.0", "react-router-dom": "^5.3.4", "rtlcss": "^4.1.0", "tslib": "^2.6.0", "utility-types": "^3.10.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-VU1RK0qb2pab0si4r7HFK37cYco8VzqLj3u1PspVipSr/z/GPVKHO4/HXbnePqHoWDk8urjyGSeatH0NIMBM1A=="],
 
-    "@docusaurus/theme-common": ["@docusaurus/theme-common@3.9.2", "", { "dependencies": { "@docusaurus/mdx-loader": "3.9.2", "@docusaurus/module-type-aliases": "3.9.2", "@docusaurus/utils": "3.9.2", "@docusaurus/utils-common": "3.9.2", "@types/history": "^4.7.11", "@types/react": "*", "@types/react-router-config": "*", "clsx": "^2.0.0", "parse-numeric-range": "^1.3.0", "prism-react-renderer": "^2.3.0", "tslib": "^2.6.0", "utility-types": "^3.10.0" }, "peerDependencies": { "@docusaurus/plugin-content-docs": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-6c4DAbR6n6nPbnZhY2V3tzpnKnGL+6aOsLvFL26VRqhlczli9eWG0VDUNoCQEPnGwDMhPS42UhSAnz5pThm5Ag=="],
+    "@docusaurus/theme-common": ["@docusaurus/theme-common@3.10.1", "", { "dependencies": { "@docusaurus/mdx-loader": "3.10.1", "@docusaurus/module-type-aliases": "3.10.1", "@docusaurus/utils": "3.10.1", "@docusaurus/utils-common": "3.10.1", "@types/history": "^4.7.11", "@types/react": "*", "@types/react-router-config": "*", "clsx": "^2.0.0", "parse-numeric-range": "^1.3.0", "prism-react-renderer": "^2.3.0", "tslib": "^2.6.0", "utility-types": "^3.10.0" }, "peerDependencies": { "@docusaurus/plugin-content-docs": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-0YtmIeoNo1fIw65LO8+/1dPgmDV86UmhMkow37gzjytuiCSQm9xob6PJy0L4kuQEMTLfUOGvkXvZr7GPrHquMA=="],
 
-    "@docusaurus/theme-search-algolia": ["@docusaurus/theme-search-algolia@3.9.2", "", { "dependencies": { "@docsearch/react": "^3.9.0 || ^4.1.0", "@docusaurus/core": "3.9.2", "@docusaurus/logger": "3.9.2", "@docusaurus/plugin-content-docs": "3.9.2", "@docusaurus/theme-common": "3.9.2", "@docusaurus/theme-translations": "3.9.2", "@docusaurus/utils": "3.9.2", "@docusaurus/utils-validation": "3.9.2", "algoliasearch": "^5.37.0", "algoliasearch-helper": "^3.26.0", "clsx": "^2.0.0", "eta": "^2.2.0", "fs-extra": "^11.1.1", "lodash": "^4.17.21", "tslib": "^2.6.0", "utility-types": "^3.10.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-GBDSFNwjnh5/LdkxCKQHkgO2pIMX1447BxYUBG2wBiajS21uj64a+gH/qlbQjDLxmGrbrllBrtJkUHxIsiwRnw=="],
+    "@docusaurus/theme-search-algolia": ["@docusaurus/theme-search-algolia@3.10.1", "", { "dependencies": { "@algolia/autocomplete-core": "^1.19.2", "@docsearch/react": "^3.9.0 || ^4.3.2", "@docusaurus/core": "3.10.1", "@docusaurus/logger": "3.10.1", "@docusaurus/plugin-content-docs": "3.10.1", "@docusaurus/theme-common": "3.10.1", "@docusaurus/theme-translations": "3.10.1", "@docusaurus/utils": "3.10.1", "@docusaurus/utils-validation": "3.10.1", "algoliasearch": "^5.37.0", "algoliasearch-helper": "^3.26.0", "clsx": "^2.0.0", "eta": "^2.2.0", "fs-extra": "^11.1.1", "lodash": "^4.17.21", "tslib": "^2.6.0", "utility-types": "^3.10.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-OTaARARVZj2GvkJQjB+1jOIxntRaXea+G+fMsNqrZBAU1O1vJKDW22R7kECOHW27oJCLFN9HKaZeRrfAUyviug=="],
 
-    "@docusaurus/theme-translations": ["@docusaurus/theme-translations@3.9.2", "", { "dependencies": { "fs-extra": "^11.1.1", "tslib": "^2.6.0" } }, "sha512-vIryvpP18ON9T9rjgMRFLr2xJVDpw1rtagEGf8Ccce4CkTrvM/fRB8N2nyWYOW5u3DdjkwKw5fBa+3tbn9P4PA=="],
+    "@docusaurus/theme-translations": ["@docusaurus/theme-translations@3.10.1", "", { "dependencies": { "fs-extra": "^11.1.1", "tslib": "^2.6.0" } }, "sha512-cLMyaKivjBVWKMJuWqyFVVgtqe8DPJNPkog0bn8W1MDVAKcPdxRFycBfC1We1RaNp7Rdk513bmtW78RR6OBxBw=="],
 
-    "@docusaurus/types": ["@docusaurus/types@3.9.2", "", { "dependencies": { "@mdx-js/mdx": "^3.0.0", "@types/history": "^4.7.11", "@types/mdast": "^4.0.2", "@types/react": "*", "commander": "^5.1.0", "joi": "^17.9.2", "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0", "utility-types": "^3.10.0", "webpack": "^5.95.0", "webpack-merge": "^5.9.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q=="],
+    "@docusaurus/types": ["@docusaurus/types@3.10.1", "", { "dependencies": { "@mdx-js/mdx": "^3.0.0", "@types/history": "^4.7.11", "@types/mdast": "^4.0.2", "@types/react": "*", "commander": "^5.1.0", "joi": "^17.9.2", "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0", "utility-types": "^3.10.0", "webpack": "^5.95.0", "webpack-merge": "^5.9.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw=="],
 
-    "@docusaurus/utils": ["@docusaurus/utils@3.9.2", "", { "dependencies": { "@docusaurus/logger": "3.9.2", "@docusaurus/types": "3.9.2", "@docusaurus/utils-common": "3.9.2", "escape-string-regexp": "^4.0.0", "execa": "5.1.1", "file-loader": "^6.2.0", "fs-extra": "^11.1.1", "github-slugger": "^1.5.0", "globby": "^11.1.0", "gray-matter": "^4.0.3", "jiti": "^1.20.0", "js-yaml": "^4.1.0", "lodash": "^4.17.21", "micromatch": "^4.0.5", "p-queue": "^6.6.2", "prompts": "^2.4.2", "resolve-pathname": "^3.0.0", "tslib": "^2.6.0", "url-loader": "^4.1.1", "utility-types": "^3.10.0", "webpack": "^5.88.1" } }, "sha512-lBSBiRruFurFKXr5Hbsl2thmGweAPmddhF3jb99U4EMDA5L+e5Y1rAkOS07Nvrup7HUMBDrCV45meaxZnt28nQ=="],
+    "@docusaurus/utils": ["@docusaurus/utils@3.10.1", "", { "dependencies": { "@docusaurus/logger": "3.10.1", "@docusaurus/types": "3.10.1", "@docusaurus/utils-common": "3.10.1", "escape-string-regexp": "^4.0.0", "execa": "^5.1.1", "file-loader": "^6.2.0", "fs-extra": "^11.1.1", "github-slugger": "^1.5.0", "globby": "^11.1.0", "gray-matter": "^4.0.3", "jiti": "^1.20.0", "js-yaml": "^4.1.0", "lodash": "^4.17.21", "micromatch": "^4.0.5", "p-queue": "^6.6.2", "prompts": "^2.4.2", "resolve-pathname": "^3.0.0", "tslib": "^2.6.0", "url-loader": "^4.1.1", "utility-types": "^3.10.0", "webpack": "^5.88.1" } }, "sha512-3ojeJry9xBYdJO6qoyyzqeJFSJBVx2mXhyDzSdjwL2+URFQMf+h25gG38iswGImicK0ELjTd1EL2xzk8hf3QPw=="],
 
-    "@docusaurus/utils-common": ["@docusaurus/utils-common@3.9.2", "", { "dependencies": { "@docusaurus/types": "3.9.2", "tslib": "^2.6.0" } }, "sha512-I53UC1QctruA6SWLvbjbhCpAw7+X7PePoe5pYcwTOEXD/PxeP8LnECAhTHHwWCblyUX5bMi4QLRkxvyZ+IT8Aw=="],
+    "@docusaurus/utils-common": ["@docusaurus/utils-common@3.10.1", "", { "dependencies": { "@docusaurus/types": "3.10.1", "tslib": "^2.6.0" } }, "sha512-5mFSgEADtnFxFH7RLw02QA5MpU5JVUCj0MPeIvi/aF4Fi45tQRIuTwXoXDqJ+1VfQJuYJGz3SI63wmGz4HvXzA=="],
 
-    "@docusaurus/utils-validation": ["@docusaurus/utils-validation@3.9.2", "", { "dependencies": { "@docusaurus/logger": "3.9.2", "@docusaurus/utils": "3.9.2", "@docusaurus/utils-common": "3.9.2", "fs-extra": "^11.2.0", "joi": "^17.9.2", "js-yaml": "^4.1.0", "lodash": "^4.17.21", "tslib": "^2.6.0" } }, "sha512-l7yk3X5VnNmATbwijJkexdhulNsQaNDwoagiwujXoxFbWLcxHQqNQ+c/IAlzrfMMOfa/8xSBZ7KEKDesE/2J7A=="],
+    "@docusaurus/utils-validation": ["@docusaurus/utils-validation@3.10.1", "", { "dependencies": { "@docusaurus/logger": "3.10.1", "@docusaurus/utils": "3.10.1", "@docusaurus/utils-common": "3.10.1", "fs-extra": "^11.2.0", "joi": "^17.9.2", "js-yaml": "^4.1.0", "lodash": "^4.17.21", "tslib": "^2.6.0" } }, "sha512-cRv1X69jwaWv47waglllgZVWzeBFLhl53XT/XED/83BerVBTC5FTP8WTcVl8Z6sZOegDSwitu/wpCSPCDOT6lg=="],
 
-    "@eightshift/ui-components": ["@eightshift/ui-components@6.3.0", "", { "dependencies": { "@fontsource-variable/geist": "^5.2.8", "@fontsource-variable/geist-mono": "^5.2.7", "@fontsource-variable/google-sans-flex": "^5.2.1", "motion": "^12.35.2" }, "peerDependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" } }, "sha512-C5fc0LTzez1UsAHOBrx8kb7rEl7UyDXP/X9RFHAr2Mjn69FE6QfXOAh+QeHM3BV66zAdGwcGQeGbtWYaMU3Vpg=="],
+    "@eightshift/ui-components": ["@eightshift/ui-components@7.3.0", "", { "dependencies": { "@fontsource-variable/google-sans-flex": "^5.2.2", "@fontsource/geist": "^5.2.8", "@fontsource/geist-mono": "^5.2.7", "eslint-plugin-react": "^7.37.5", "eslint-plugin-react-hooks": "^7.0.1", "motion": "^12.38.0" }, "peerDependencies": { "react": "^18.3.1", "react-dom": "^18.3.1" } }, "sha512-bwfv9ArcV+8+/VOTY20X7F+J1C6ozX5QgsxTfV8TPDVyEjS0ZTpBXayhEFvA471hdbrdoJ5TjtTGdBeeQEk/lA=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.0", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g=="],
 
@@ -486,11 +485,11 @@
 
     "@eslint/js": ["@eslint/js@8.57.1", "", {}, "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q=="],
 
-    "@fontsource-variable/geist": ["@fontsource-variable/geist@5.2.8", "", {}, "sha512-cJ6m9e+8MQ5dCYJsLylfZrgBh6KkG4bOLckB35Tr9J/EqdkEM6QllH5PxqP1dhTvFup+HtMRPuz9xOjxXJggxw=="],
+    "@fontsource-variable/google-sans-flex": ["@fontsource-variable/google-sans-flex@5.2.3", "", {}, "sha512-g5z9WANJW56gZTWJvu7mIHOiHJaffkk/dhOKqEiK4Nxnsk8lnGnijvGt4vF4KD2KWzscXBOB9XR2sfvTPSi5hA=="],
 
-    "@fontsource-variable/geist-mono": ["@fontsource-variable/geist-mono@5.2.7", "", {}, "sha512-ZKlZ5sjtalb2TwXKs400mAGDlt/+2ENLNySPx0wTz3bP3mWARCsUW+rpxzZc7e05d2qGch70pItt3K4qttbIYA=="],
+    "@fontsource/geist": ["@fontsource/geist@5.2.8", "", {}, "sha512-pI54klK6vz8fVpAVyV+iODGLEzw73cs1XJqV9PIXgW8MYMmBcwK6lKKaWqJrNHwEx8ppz9cuhussb6arXQ/PVQ=="],
 
-    "@fontsource-variable/google-sans-flex": ["@fontsource-variable/google-sans-flex@5.2.1", "", {}, "sha512-CZzNhNK6NTjJsX3SP2g/WWzldFzSiSHrE1DtXh2Nkbflb40CGtP3G+1OABongwrNV3Tu/bUfirgcP14ajcglMw=="],
+    "@fontsource/geist-mono": ["@fontsource/geist-mono@5.2.7", "", {}, "sha512-xVPVFISJg/K0VVd+aQN0Y7X/sw9hUcJPyDWFJ5GpyU3bHELhoRsJkPSRSHXW32mOi0xZCUQDOaPj1sqIFJ1FGg=="],
 
     "@hapi/hoek": ["@hapi/hoek@9.3.0", "", {}, "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="],
 
@@ -680,7 +679,7 @@
 
     "@types/graceful-fs": ["@types/graceful-fs@4.1.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ=="],
 
-    "@types/gtag.js": ["@types/gtag.js@0.0.12", "", {}, "sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg=="],
+    "@types/gtag.js": ["@types/gtag.js@0.0.20", "", {}, "sha512-wwAbk3SA2QeU67unN7zPxjEHmPmlXwZXZvQEpbEUQuMCRGgKyE1m6XDuTUA9b6pCGb/GqJmdfMOY5LuDjJSbbg=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
@@ -864,6 +863,8 @@
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "ansis": ["ansis@3.17.0", "", {}, "sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg=="],
+
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
@@ -950,7 +951,7 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
-    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.10", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ=="],
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.29", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ=="],
 
     "batch": ["batch@0.6.1", "", {}, "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw=="],
 
@@ -1008,7 +1009,7 @@
 
     "caniuse-api": ["caniuse-api@3.0.0", "", { "dependencies": { "browserslist": "^4.0.0", "caniuse-lite": "^1.0.0", "lodash.memoize": "^4.1.2", "lodash.uniq": "^4.5.0" } }, "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw=="],
 
-    "caniuse-lite": ["caniuse-lite@1.0.30001781", "", {}, "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw=="],
+    "caniuse-lite": ["caniuse-lite@1.0.30001792", "", {}, "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw=="],
 
     "case-sensitive-paths-webpack-plugin": ["case-sensitive-paths-webpack-plugin@2.4.0", "", {}, "sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw=="],
 
@@ -1109,6 +1110,8 @@
     "cookie": ["cookie@0.7.1", "", {}, "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w=="],
 
     "cookie-signature": ["cookie-signature@1.0.6", "", {}, "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="],
+
+    "copy-text-to-clipboard": ["copy-text-to-clipboard@3.2.2", "", {}, "sha512-T6SqyLd1iLuqPA90J5N4cTalrtovCySh58iiZDGJ6FGznbclKh4UI+FGacQSgFzwKG77W7XT5gwbVEbd9cIH1A=="],
 
     "copy-webpack-plugin": ["copy-webpack-plugin@11.0.0", "", { "dependencies": { "fast-glob": "^3.2.11", "glob-parent": "^6.0.1", "globby": "^13.1.1", "normalize-path": "^3.0.0", "schema-utils": "^4.0.0", "serialize-javascript": "^6.0.0" }, "peerDependencies": { "webpack": "^5.1.0" } }, "sha512-fX2MWpamkW0hZxMEg0+mYnA40LTosOSa5TqZ9GYIBzyJa9C3QUaMPSE2xAi/buNr8u89SfD9wHSQVBzrRa/SOQ=="],
 
@@ -1236,7 +1239,7 @@
 
     "dns-packet": ["dns-packet@5.6.1", "", { "dependencies": { "@leichtgewicht/ip-codec": "^2.0.1" } }, "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw=="],
 
-    "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
+    "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 
     "dom-converter": ["dom-converter@0.2.0", "", { "dependencies": { "utila": "~0.4" } }, "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA=="],
 
@@ -1344,7 +1347,7 @@
 
     "eslint-plugin-react": ["eslint-plugin-react@7.37.5", "", { "dependencies": { "array-includes": "^3.1.8", "array.prototype.findlast": "^1.2.5", "array.prototype.flatmap": "^1.3.3", "array.prototype.tosorted": "^1.1.4", "doctrine": "^2.1.0", "es-iterator-helpers": "^1.2.1", "estraverse": "^5.3.0", "hasown": "^2.0.2", "jsx-ast-utils": "^2.4.1 || ^3.0.0", "minimatch": "^3.1.2", "object.entries": "^1.1.9", "object.fromentries": "^2.0.8", "object.values": "^1.2.1", "prop-types": "^15.8.1", "resolve": "^2.0.0-next.5", "semver": "^6.3.1", "string.prototype.matchall": "^4.0.12", "string.prototype.repeat": "^1.0.0" }, "peerDependencies": { "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7" } }, "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA=="],
 
-    "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@4.6.2", "", { "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0" } }, "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ=="],
+    "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@7.1.1", "", { "dependencies": { "@babel/core": "^7.24.4", "@babel/parser": "^7.24.4", "hermes-parser": "^0.25.1", "zod": "^3.25.0 || ^4.0.0", "zod-validation-error": "^3.5.0 || ^4.0.0" }, "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0" } }, "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g=="],
 
     "eslint-plugin-testing-library": ["eslint-plugin-testing-library@5.11.1", "", { "dependencies": { "@typescript-eslint/utils": "^5.58.0" }, "peerDependencies": { "eslint": "^7.5.0 || ^8.0.0" } }, "sha512-5eX9e1Kc2PqVRed3taaLnAAqPZGEX75C+M/rXzUAI3wIg/ZxzUm1OVAwfe/O+vE+6YXOLetSe9g5GKD2ecXipw=="],
 
@@ -1362,7 +1365,7 @@
 
     "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
 
-    "estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
     "estree-util-attach-comments": ["estree-util-attach-comments@3.0.0", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw=="],
 
@@ -1423,8 +1426,6 @@
     "fb-watchman": ["fb-watchman@2.0.2", "", { "dependencies": { "bser": "2.1.1" } }, "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA=="],
 
     "feed": ["feed@4.2.2", "", { "dependencies": { "xml-js": "^1.6.11" } }, "sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ=="],
-
-    "figures": ["figures@3.2.0", "", { "dependencies": { "escape-string-regexp": "^1.0.5" } }, "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg=="],
 
     "file-entry-cache": ["file-entry-cache@6.0.1", "", { "dependencies": { "flat-cache": "^3.0.4" } }, "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg=="],
 
@@ -1571,6 +1572,10 @@
     "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
 
     "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
+
+    "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
+
+    "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
 
     "history": ["history@4.10.1", "", { "dependencies": { "@babel/runtime": "^7.1.2", "loose-envify": "^1.2.0", "resolve-pathname": "^3.0.0", "tiny-invariant": "^1.0.2", "tiny-warning": "^1.0.0", "value-equal": "^1.0.1" } }, "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew=="],
 
@@ -1936,7 +1941,7 @@
 
     "markdown-extensions": ["markdown-extensions@2.0.0", "", {}, "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q=="],
 
-    "markdown-table": ["markdown-table@2.0.0", "", { "dependencies": { "repeat-string": "^1.0.0" } }, "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A=="],
+    "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -2080,7 +2085,7 @@
 
     "minimalistic-assert": ["minimalistic-assert@1.0.1", "", {}, "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="],
 
-    "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
@@ -2476,7 +2481,7 @@
 
     "react-loadable": ["@docusaurus/react-loadable@6.0.0", "", { "dependencies": { "@types/react": "*" }, "peerDependencies": { "react": "*" } }, "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ=="],
 
-    "react-loadable-ssr-addon-v5-slorber": ["react-loadable-ssr-addon-v5-slorber@1.0.1", "", { "dependencies": { "@babel/runtime": "^7.10.3" }, "peerDependencies": { "react-loadable": "*", "webpack": ">=4.41.1 || 5.x" } }, "sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A=="],
+    "react-loadable-ssr-addon-v5-slorber": ["react-loadable-ssr-addon-v5-slorber@1.0.3", "", { "dependencies": { "@babel/runtime": "^7.10.3" }, "peerDependencies": { "react-loadable": "*", "webpack": ">=4.41.1 || 5.x" } }, "sha512-GXfh9VLwB5ERaCsU6RULh7tkemeX15aNh6wuMEBtfdyMa7fFG8TXrhXlx1SoEK2Ty/l6XIkzzYIQmyaWW3JgdQ=="],
 
     "react-refresh": ["react-refresh@0.11.0", "", {}, "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="],
 
@@ -2549,8 +2554,6 @@
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
     "renderkid": ["renderkid@3.0.0", "", { "dependencies": { "css-select": "^4.1.3", "dom-converter": "^0.2.0", "htmlparser2": "^6.1.0", "lodash": "^4.17.21", "strip-ansi": "^6.0.1" } }, "sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg=="],
-
-    "repeat-string": ["repeat-string@1.6.1", "", {}, "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
@@ -2632,7 +2635,7 @@
 
     "serialize-javascript": ["serialize-javascript@6.0.2", "", { "dependencies": { "randombytes": "^2.1.0" } }, "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g=="],
 
-    "serve-handler": ["serve-handler@6.1.6", "", { "dependencies": { "bytes": "3.0.0", "content-disposition": "0.5.2", "mime-types": "2.1.18", "minimatch": "3.1.2", "path-is-inside": "1.0.2", "path-to-regexp": "3.3.0", "range-parser": "1.2.0" } }, "sha512-x5RL9Y2p5+Sh3D38Fh9i/iQ5ZK+e4xuXRd/pGbM4D13tgo/MGwbttUk8emytcr1YYzBYs+apnUngBDFYfpjPuQ=="],
+    "serve-handler": ["serve-handler@6.1.7", "", { "dependencies": { "bytes": "3.0.0", "content-disposition": "0.5.2", "mime-types": "2.1.18", "minimatch": "3.1.5", "path-is-inside": "1.0.2", "path-to-regexp": "3.3.0", "range-parser": "1.2.0" } }, "sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg=="],
 
     "serve-index": ["serve-index@1.9.1", "", { "dependencies": { "accepts": "~1.3.4", "batch": "0.6.1", "debug": "2.6.9", "escape-html": "~1.0.3", "http-errors": "~1.6.2", "mime-types": "~2.1.17", "parseurl": "~1.3.2" } }, "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw=="],
 
@@ -2914,6 +2917,8 @@
 
     "url-parse": ["url-parse@1.5.10", "", { "dependencies": { "querystringify": "^2.1.1", "requires-port": "^1.0.0" } }, "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ=="],
 
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "util.promisify": ["util.promisify@1.0.1", "", { "dependencies": { "define-properties": "^1.1.3", "es-abstract": "^1.17.2", "has-symbols": "^1.0.1", "object.getownpropertydescriptors": "^2.1.0" } }, "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA=="],
@@ -2966,7 +2971,7 @@
 
     "webpack-sources": ["webpack-sources@3.3.3", "", {}, "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg=="],
 
-    "webpackbar": ["webpackbar@6.0.1", "", { "dependencies": { "ansi-escapes": "^4.3.2", "chalk": "^4.1.2", "consola": "^3.2.3", "figures": "^3.2.0", "markdown-table": "^2.0.0", "pretty-time": "^1.1.0", "std-env": "^3.7.0", "wrap-ansi": "^7.0.0" }, "peerDependencies": { "webpack": "3 || 4 || 5" } }, "sha512-TnErZpmuKdwWBdMoexjio3KKX6ZtoKHRVvLIU0A47R0VVBDtx3ZyOJDktgYixhoJokZTYTt1Z37OkO9pnGJa9Q=="],
+    "webpackbar": ["webpackbar@7.0.0", "", { "dependencies": { "ansis": "^3.2.0", "consola": "^3.2.3", "pretty-time": "^1.1.0", "std-env": "^3.7.0" }, "peerDependencies": { "@rspack/core": "*", "webpack": "3 || 4 || 5" }, "optionalPeers": ["@rspack/core", "webpack"] }, "sha512-aS9soqSO2iCHgqHoCrj4LbfGQUboDCYJPSFOAchEK+9psIjNrfSWW4Y0YEz67MKURNvMmfo0ycOg9d/+OOf9/Q=="],
 
     "websocket-driver": ["websocket-driver@0.7.4", "", { "dependencies": { "http-parser-js": ">=0.5.1", "safe-buffer": ">=5.1.0", "websocket-extensions": ">=0.1.1" } }, "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg=="],
 
@@ -3062,7 +3067,13 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
+
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@algolia/autocomplete-preset-algolia/@algolia/autocomplete-shared": ["@algolia/autocomplete-shared@1.17.9", "", { "peerDependencies": { "@algolia/client-search": ">= 4.9.1 < 6", "algoliasearch": ">= 4.9.1 < 6" } }, "sha512-iDf05JDQ7I0b7JEA/9IektxN/80a2MZ1ToohfmNS3rfeuQnIKI3IJlIafD0xu4StbtQTghx9T3Maa97ytkXenQ=="],
 
     "@apideck/better-ajv-errors/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
@@ -3104,6 +3115,8 @@
 
     "@csstools/selector-resolve-nested/postcss-selector-parser": ["postcss-selector-parser@7.1.0", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA=="],
 
+    "@docsearch/react/@algolia/autocomplete-core": ["@algolia/autocomplete-core@1.17.9", "", { "dependencies": { "@algolia/autocomplete-plugin-algolia-insights": "1.17.9", "@algolia/autocomplete-shared": "1.17.9" } }, "sha512-O7BxrpLDPJWWHv/DLA9DRFWs+iY1uOJZkqUwjS5HSZAGcl0hIVCQ97LTLewiZmZ402JYUrun+8NqFP+hCknlbQ=="],
+
     "@docusaurus/bundler/babel-loader": ["babel-loader@9.2.1", "", { "dependencies": { "find-cache-dir": "^4.0.0", "schema-utils": "^4.0.0" }, "peerDependencies": { "@babel/core": "^7.12.0", "webpack": ">=5" } }, "sha512-fqe8naHt46e0yIdkjUZYqddSXfej3AHajX+CSO5X7oy0EmPc6o5Xh+RClNoHjnieWz9AW4kZxW9yyFMhVB1QLA=="],
 
     "@docusaurus/bundler/css-minimizer-webpack-plugin": ["css-minimizer-webpack-plugin@5.0.1", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.18", "cssnano": "^6.0.1", "jest-worker": "^29.4.3", "postcss": "^8.4.24", "schema-utils": "^4.0.1", "serialize-javascript": "^6.0.1" }, "peerDependencies": { "webpack": "^5.0.0" } }, "sha512-3caImjKFQkS+ws1TGcFn0V1HyDJFq1Euy589JlD6/3rV2kj+w7r5G9WDMgSHvpvXHNZ2calVypZWuEDQd9wfLg=="],
@@ -3115,6 +3128,10 @@
     "@docusaurus/plugin-svgr/@svgr/webpack": ["@svgr/webpack@8.1.0", "", { "dependencies": { "@babel/core": "^7.21.3", "@babel/plugin-transform-react-constant-elements": "^7.21.3", "@babel/preset-env": "^7.20.2", "@babel/preset-react": "^7.18.6", "@babel/preset-typescript": "^7.21.0", "@svgr/core": "8.1.0", "@svgr/plugin-jsx": "8.1.0", "@svgr/plugin-svgo": "8.1.0" } }, "sha512-LnhVjMWyMQV9ZmeEy26maJk+8HTIbd59cH4F2MJ439k9DqejRisfFNGAPvRYlKETuh9LrImlS8aKsBgKjMA8WA=="],
 
     "@docusaurus/types/webpack-merge": ["webpack-merge@5.10.0", "", { "dependencies": { "clone-deep": "^4.0.1", "flat": "^5.0.2", "wildcard": "^2.0.0" } }, "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA=="],
+
+    "@eslint/eslintrc/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "@humanwhocodes/config-array/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
@@ -3240,13 +3257,21 @@
 
     "escodegen/esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
+    "escodegen/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
+
     "escodegen/optionator": ["optionator@0.8.3", "", { "dependencies": { "deep-is": "~0.1.3", "fast-levenshtein": "~2.0.6", "levn": "~0.3.0", "prelude-ls": "~1.1.2", "type-check": "~0.3.2", "word-wrap": "~1.2.3" } }, "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA=="],
 
     "escodegen/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
+    "eslint/doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
+
     "eslint/eslint-scope": ["eslint-scope@7.2.2", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg=="],
 
     "eslint/glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "eslint/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "eslint-config-react-app/eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@4.6.2", "", { "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0" } }, "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ=="],
 
     "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
@@ -3254,25 +3279,23 @@
 
     "eslint-plugin-import/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
-    "eslint-plugin-import/doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
+    "eslint-plugin-import/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "eslint-plugin-import/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "eslint-plugin-react/doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
+    "eslint-plugin-jsx-a11y/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
-    "eslint-plugin-react/estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+    "eslint-plugin-react/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "eslint-plugin-react/resolve": ["resolve@2.0.0-next.5", "", { "dependencies": { "is-core-module": "^2.13.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA=="],
 
     "eslint-plugin-react/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "eslint-scope/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
+
     "eslint-webpack-plugin/jest-worker": ["jest-worker@28.1.3", "", { "dependencies": { "@types/node": "*", "merge-stream": "^2.0.0", "supports-color": "^8.0.0" } }, "sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g=="],
 
     "eslint-webpack-plugin/schema-utils": ["schema-utils@4.3.2", "", { "dependencies": { "@types/json-schema": "^7.0.9", "ajv": "^8.9.0", "ajv-formats": "^2.1.1", "ajv-keywords": "^5.1.0" } }, "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ=="],
-
-    "esquery/estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
-
-    "esrecurse/estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
     "express/content-disposition": ["content-disposition@0.5.4", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ=="],
 
@@ -3281,8 +3304,6 @@
     "express/path-to-regexp": ["path-to-regexp@0.1.12", "", {}, "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="],
 
     "express/range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
-
-    "figures/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
     "filelist/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
 
@@ -3296,9 +3317,13 @@
 
     "fork-ts-checker-webpack-plugin/memfs": ["memfs@3.6.0", "", { "dependencies": { "fs-monkey": "^1.0.4" } }, "sha512-EGowvkkgbMcIChjMTMkESFDbZeSh8xZ7kNSF0hAiAN4Jh6jgHCRS0Ga/+C8y6Au+oqpezRHCfPsmJ2+DwAgiwQ=="],
 
+    "fork-ts-checker-webpack-plugin/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
     "fork-ts-checker-webpack-plugin/schema-utils": ["schema-utils@2.7.0", "", { "dependencies": { "@types/json-schema": "^7.0.4", "ajv": "^6.12.2", "ajv-keywords": "^3.4.1" } }, "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A=="],
 
     "fork-ts-checker-webpack-plugin/tapable": ["tapable@1.1.3", "", {}, "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="],
+
+    "glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "global-prefix/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
@@ -3373,8 +3398,6 @@
     "mdast-util-frontmatter/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "mdast-util-gfm-autolink-literal/micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
-
-    "mdast-util-gfm-table/markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
     "micromark/micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
 
@@ -3532,6 +3555,8 @@
 
     "react-scripts/webpack-dev-server": ["webpack-dev-server@4.15.2", "", { "dependencies": { "@types/bonjour": "^3.5.9", "@types/connect-history-api-fallback": "^1.3.5", "@types/express": "^4.17.13", "@types/serve-index": "^1.9.1", "@types/serve-static": "^1.13.10", "@types/sockjs": "^0.3.33", "@types/ws": "^8.5.5", "ansi-html-community": "^0.0.8", "bonjour-service": "^1.0.11", "chokidar": "^3.5.3", "colorette": "^2.0.10", "compression": "^1.7.4", "connect-history-api-fallback": "^2.0.0", "default-gateway": "^6.0.3", "express": "^4.17.3", "graceful-fs": "^4.2.6", "html-entities": "^2.3.2", "http-proxy-middleware": "^2.0.3", "ipaddr.js": "^2.0.1", "launch-editor": "^2.6.0", "open": "^8.0.9", "p-retry": "^4.5.0", "rimraf": "^3.0.2", "schema-utils": "^4.0.0", "selfsigned": "^2.1.1", "serve-index": "^1.9.1", "sockjs": "^0.3.24", "spdy": "^4.0.2", "webpack-dev-middleware": "^5.3.4", "ws": "^8.13.0" }, "peerDependencies": { "webpack": "^4.37.0 || ^5.0.0" }, "optionalPeers": ["webpack"], "bin": { "webpack-dev-server": "bin/webpack-dev-server.js" } }, "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g=="],
 
+    "recursive-readdir/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
     "regjsparser/jsesc": ["jsesc@3.0.2", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g=="],
 
     "renderkid/htmlparser2": ["htmlparser2@6.1.0", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.0.0", "domutils": "^2.5.2", "entities": "^2.0.0" } }, "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A=="],
@@ -3598,6 +3623,8 @@
 
     "terser-webpack-plugin/schema-utils": ["schema-utils@4.3.2", "", { "dependencies": { "@types/json-schema": "^7.0.9", "ajv": "^8.9.0", "ajv-formats": "^2.1.1", "ajv-keywords": "^5.1.0" } }, "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ=="],
 
+    "test-exclude/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
     "tough-cookie/universalify": ["universalify@0.2.0", "", {}, "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="],
 
     "tsconfig-paths/json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
@@ -3628,8 +3655,6 @@
 
     "webpack-manifest-plugin/webpack-sources": ["webpack-sources@2.3.1", "", { "dependencies": { "source-list-map": "^2.0.1", "source-map": "^0.6.1" } }, "sha512-y9EI9AO42JjEcrTJFOYmVywVZdKVUfOvDUPsJea5GIr1JOEGFVqwlY2K098fFoIjOkDzHn2AjRvM8dsBZu+gCA=="],
 
-    "webpackbar/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
     "whatwg-encoding/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
     "which-builtin-type/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
@@ -3653,6 +3678,10 @@
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@apideck/better-ajv-errors/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "@docsearch/react/@algolia/autocomplete-core/@algolia/autocomplete-plugin-algolia-insights": ["@algolia/autocomplete-plugin-algolia-insights@1.17.9", "", { "dependencies": { "@algolia/autocomplete-shared": "1.17.9" }, "peerDependencies": { "search-insights": ">= 1 < 3" } }, "sha512-u1fEHkCbWF92DBeB/KHeMacsjsoI0wFhjZtlCq2ddZbAehshbZST6Hs0Avkc0s+4UyBGbMDnSuXHLuvRWK5iDQ=="],
+
+    "@docsearch/react/@algolia/autocomplete-core/@algolia/autocomplete-shared": ["@algolia/autocomplete-shared@1.17.9", "", { "peerDependencies": { "@algolia/client-search": ">= 4.9.1 < 6", "algoliasearch": ">= 4.9.1 < 6" } }, "sha512-iDf05JDQ7I0b7JEA/9IektxN/80a2MZ1ToohfmNS3rfeuQnIKI3IJlIafD0xu4StbtQTghx9T3Maa97ytkXenQ=="],
 
     "@docusaurus/bundler/babel-loader/find-cache-dir": ["find-cache-dir@4.0.0", "", { "dependencies": { "common-path-prefix": "^3.0.0", "pkg-dir": "^7.0.0" } }, "sha512-9ZonPT4ZAK4a+1pUPVPZJapbi7O5qbbJPdYw/NOQWZZbVLdDTYM3A4R9z/DpAM08IDaFGsvPgiGZ82WEwUDWjg=="],
 
@@ -3834,8 +3863,6 @@
 
     "eslint-webpack-plugin/schema-utils/ajv-keywords": ["ajv-keywords@5.1.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3" }, "peerDependencies": { "ajv": "^8.8.2" } }, "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw=="],
 
-    "eslint/eslint-scope/estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
-
     "express/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
@@ -3863,8 +3890,6 @@
     "jest-watcher/string-length/char-regex": ["char-regex@1.0.2", "", {}, "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="],
 
     "jsdom/escodegen/esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
-
-    "jsdom/escodegen/estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
     "jsdom/escodegen/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -3965,8 +3990,6 @@
     "webpack/schema-utils/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
     "webpack/schema-utils/ajv-keywords": ["ajv-keywords@5.1.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3" }, "peerDependencies": { "ajv": "^8.8.2" } }, "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw=="],
-
-    "webpackbar/wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "workbox-build/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -4149,8 +4172,6 @@
     "webpack-dev-server/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "webpack/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "webpackbar/wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "@docusaurus/bundler/babel-loader/find-cache-dir/pkg-dir/find-up": ["find-up@6.3.0", "", { "dependencies": { "locate-path": "^7.1.0", "path-exists": "^5.0.0" } }, "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw=="],
 

--- a/website/package.json
+++ b/website/package.json
@@ -32,19 +32,20 @@
 		"clear": "docusaurus clear"
 	},
 	"dependencies": {
-		"@docusaurus/core": "^3.9.2",
-		"@docusaurus/preset-classic": "^3.9.2",
-		"@eightshift/ui-components": "^6.3.0",
+		"@docusaurus/core": "^3.10.1",
+		"@docusaurus/preset-classic": "^3.10.1",
+		"@eightshift/ui-components": "^7.3.0",
 		"@infinum/docusaurus-theme": "^0.6.0",
 		"@mdx-js/react": "^3.1.1",
 		"@wp-playground/client": "^2.0.22",
-		"caniuse-lite": "^1.0.30001781",
+		"caniuse-lite": "^1.0.30001792",
 		"clsx": "^2.1.1",
 		"es-text-loader": "file:plugins/es-text-loader",
 		"prism-react-renderer": "^2.4.1",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"react-scripts": "^5.0.1"
+		"react-scripts": "^5.0.1",
+		"use-sync-external-store": "^1.6.0"
 	},
 	"browserslist": {
 		"production": [
@@ -59,7 +60,7 @@
 		]
 	},
 	"devDependencies": {
-		"baseline-browser-mapping": "^2.10.10",
+		"baseline-browser-mapping": "^2.10.29",
 		"raw-loader": "^4.0.2"
 	}
 }

--- a/website/sidebars-components.js
+++ b/website/sidebars-components.js
@@ -9,7 +9,12 @@ module.exports = {
 				{
 					type: 'category',
 					label: 'Icons',
-					items: ['es-ui-components/ui-icons', 'es-ui-components/block-icons'],
+					items: [
+						'es-ui-components/ui-icons',
+						'es-ui-components/block-icons',
+						'es-ui-components/jsx-svg',
+						'es-ui-components/spinner',
+					],
 				},
 				'es-ui-components/base-control',
 				{
@@ -106,15 +111,15 @@ module.exports = {
 					label: 'Panels',
 					items: ['es-ui-components/container-panel', 'es-ui-components/options-panel'],
 				},
+				'es-ui-components/utilities',
+				'es-ui-components/wp-overrides',
 				'es-ui-components/migrations',
 			],
 		},
 		{
 			type: 'category',
 			label: 'Frontend libs components',
-			items: [
-				'fe-libs-components/introduction'
-			],
+			items: ['fe-libs-components/introduction'],
 		},
 	],
 };

--- a/website/ui-components/components/component-showcase.js
+++ b/website/ui-components/components/component-showcase.js
@@ -22,7 +22,7 @@ export const ComponentShowcase = ({
 						className={clsx(
 							'es:border es:border-dashed es:border-secondary-200 es:p-4 es:rounded-lg esd-space-v es:shrink-0 esd-showcase',
 							fitWidth ? 'es:w-fit' : 'esd-showcase-w',
-							className
+							className,
 						)}
 					>
 						{typeof children === 'function' && children(data, setData)}

--- a/website/ui-components/es-ui-components/animated-visibility.mdx
+++ b/website/ui-components/es-ui-components/animated-visibility.mdx
@@ -2,7 +2,6 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { AnimatedVisibility, Checkbox, OptionSelect } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
 
 Allows showing/hiding content in an animated way. After hiding, the content is unmounted from the DOM.
 

--- a/website/ui-components/es-ui-components/animated-visibility.mdx
+++ b/website/ui-components/es-ui-components/animated-visibility.mdx
@@ -1,5 +1,9 @@
 # Animated visibility
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/animated-visibility)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { AnimatedVisibility, Checkbox, OptionSelect } from '@eightshift/ui-components';
 

--- a/website/ui-components/es-ui-components/async-multi-select.mdx
+++ b/website/ui-components/es-ui-components/async-multi-select.mdx
@@ -2,7 +2,7 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { AsyncMultiSelect } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+
 import { demoGetData } from './select-helpers';
 
 <ComponentShowcase defaultValue={[]}>

--- a/website/ui-components/es-ui-components/async-multi-select.mdx
+++ b/website/ui-components/es-ui-components/async-multi-select.mdx
@@ -1,5 +1,9 @@
 # Async multi-select
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/select)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { AsyncMultiSelect } from '@eightshift/ui-components';
 

--- a/website/ui-components/es-ui-components/async-select.mdx
+++ b/website/ui-components/es-ui-components/async-select.mdx
@@ -1,5 +1,9 @@
 # Async single select
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/select)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { AsyncSelect } from '@eightshift/ui-components';
 

--- a/website/ui-components/es-ui-components/async-select.mdx
+++ b/website/ui-components/es-ui-components/async-select.mdx
@@ -2,7 +2,7 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { AsyncSelect } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+
 import { demoGetData } from './select-helpers';
 
 <ComponentShowcase>

--- a/website/ui-components/es-ui-components/base-control.mdx
+++ b/website/ui-components/es-ui-components/base-control.mdx
@@ -1,7 +1,7 @@
 # Control base
 
 import { ComponentShowcase } from '../components/component-showcase';
-import { BaseControl, Button } from '@eightshift/ui-components';
+import { BaseControl, Button, Container, ContainerGroup } from '@eightshift/ui-components';
 import { emptyCircle, emptyRect } from '@eightshift/ui-components/icons';
 
 import { globalManifest, responsiveOptions, breakpointNames } from './responsive-helpers';
@@ -131,3 +131,100 @@ For the complete list of props, use your IDE's autocomplete functionality.
 	<span>This is demo content</span>
 </BaseControl>
 ```
+
+## Container
+
+A styled wrapper for sections of controls. Shipped from the same module as `BaseControl` and used internally by many higher-level components.
+
+<ComponentShowcase>
+	<Container>
+		<span>Container contents</span>
+	</Container>
+</ComponentShowcase>
+
+```jsx
+<Container>
+	<span>Container contents</span>
+</Container>
+```
+
+### Highlighted props
+
+| Prop                              | Description                                                                                                 |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `as`                              | Element type to render. Defaults to `div`. Any HTML tag or component is accepted.                           |
+| `accent`                          | Switches to the accent color scheme.                                                                        |
+| `elevated`                        | Adds a subtle shadow and inset highlight for emphasis.                                                      |
+| `primary`                         | Renders as a pill-shaped (`rounded-full`) container.                                                        |
+| `compact`                         | Reduces vertical padding and minimum height.                                                                |
+| `standalone`                      | When `true`, the container is rendered with rounded corners on its own (not as part of a `ContainerGroup`). |
+| `horizontal`                      | Hint for `ContainerGroup` to render this child as part of a horizontal group (set automatically by parent). |
+| `centered`                        | Vertically centers the contents.                                                                            |
+| `lessSpaceStart` / `lessSpaceEnd` | Reduces left / right padding.                                                                               |
+| `hidden`                          | When `true`, the container renders nothing.                                                                 |
+| `className`                       | Appended to the default class list.                                                                         |
+
+#### Variants
+
+<ComponentShowcase>
+	<ContainerGroup>
+		<Container>Default</Container>
+		<Container accent>Accent</Container>
+		<Container elevated>Elevated</Container>
+		<Container
+			accent
+			elevated
+		>
+			Accent + elevated
+		</Container>
+	</ContainerGroup>
+</ComponentShowcase>
+
+```jsx
+<ContainerGroup>
+	<Container>Default</Container>
+	<Container accent>Accent</Container>
+	<Container elevated>Elevated</Container>
+	<Container
+		accent
+		elevated
+	>
+		Accent + elevated
+	</Container>
+</ContainerGroup>
+```
+
+## ContainerGroup
+
+Groups multiple `Container` components, applies consistent spacing between them, and rounds the outer corners. Children that are `Container` instances automatically inherit the group's `horizontal` flag.
+
+<ComponentShowcase>
+	<ContainerGroup label='Group label'>
+		<Container>First</Container>
+		<Container>Second</Container>
+		<Container>Third</Container>
+	</ContainerGroup>
+</ComponentShowcase>
+
+```jsx
+<ContainerGroup label='Group label'>
+	<Container>First</Container>
+	<Container>Second</Container>
+	<Container>Third</Container>
+</ContainerGroup>
+```
+
+### Highlighted props
+
+| Prop            | Description                                                                                                 |
+| --------------- | ----------------------------------------------------------------------------------------------------------- |
+| `as`            | Element type to render. Defaults to `div`.                                                                  |
+| `label`         | Optional label rendered above the group.                                                                    |
+| `horizontal`    | Stacks children horizontally instead of vertically and propagates the flag to child `Container` components. |
+| `wrapClassName` | Class applied to the outer wrapper element when a `label` is provided.                                      |
+| `className`     | Class applied to the inner flex container.                                                                  |
+| `hidden`        | When `true`, the group renders nothing.                                                                     |
+
+:::tip
+`ContainerGroup` will render `null` if all of its children are falsy — no empty wrappers in the DOM.
+:::

--- a/website/ui-components/es-ui-components/base-control.mdx
+++ b/website/ui-components/es-ui-components/base-control.mdx
@@ -1,5 +1,9 @@
 # Control base
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/base-control)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { BaseControl, Button, Container, ContainerGroup } from '@eightshift/ui-components';
 import { emptyCircle, emptyRect } from '@eightshift/ui-components/icons';

--- a/website/ui-components/es-ui-components/base-control.mdx
+++ b/website/ui-components/es-ui-components/base-control.mdx
@@ -2,7 +2,8 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { BaseControl, Button } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import { emptyCircle, emptyRect } from '@eightshift/ui-components/icons';
+
 import { globalManifest, responsiveOptions, breakpointNames } from './responsive-helpers';
 
 The base for a lot of Eightshift UI components controls.
@@ -12,7 +13,7 @@ Allows creating your controls that will fit in nicely with Eightshift UI compone
 <ComponentShowcase>
 	<BaseControl
 		label='Label'
-		icon={icons.emptyCircle}
+		icon={emptyCircle}
 	>
 		<div className='es:w-full es:rounded-lg es:bg-gray-100 es:text-sm es:p-4 es:min-h-40'>
 			<span>This is demo content</span>
@@ -23,7 +24,7 @@ Allows creating your controls that will fit in nicely with Eightshift UI compone
 ```jsx
 <BaseControl
 	label='Label'
-	icon={icons.emptyCircle}
+	icon={emptyCircle}
 >
 	<span>This is demo content</span>
 </BaseControl>
@@ -38,7 +39,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 <ComponentShowcase>
 	<BaseControl
 		label='Label'
-		icon={icons.emptyCircle}
+		icon={emptyCircle}
 		help='This is help text'
 	>
 		<div className='es:w-full es:rounded-lg es:bg-gray-100 es:text-sm es:p-4 es:min-h-40'>
@@ -50,7 +51,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 ```jsx
 <BaseControl
 	label='Label'
-	icon={icons.emptyCircle}
+	icon={emptyCircle}
 	// highlight-next-line
 	help='This is help text'
 >
@@ -63,15 +64,15 @@ For the complete list of props, use your IDE's autocomplete functionality.
 <ComponentShowcase>
 	<BaseControl
 		label='Label'
-		icon={icons.emptyCircle}
+		icon={emptyCircle}
 		actions={
 			<>
 				<Button
-					icon={icons.emptyCircle}
+					icon={emptyCircle}
 					size='small'
 				/>
 				<Button
-					icon={icons.emptyRect}
+					icon={emptyRect}
 					size='small'
 				/>
 			</>
@@ -86,16 +87,16 @@ For the complete list of props, use your IDE's autocomplete functionality.
 ```jsx
 <BaseControl
 	label='Label'
-	icon={icons.emptyCircle}
+	icon={emptyCircle}
 	// highlight-start
 	actions={
 		<>
 			<Button
-				icon={icons.emptyCircle}
+				icon={emptyCircle}
 				size='small'
 			/>
 			<Button
-				icon={icons.emptyRect}
+				icon={emptyRect}
 				size='small'
 			/>
 		</>
@@ -111,7 +112,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 <ComponentShowcase>
 	<BaseControl
 		label='Label'
-		icon={icons.emptyCircle}
+		icon={emptyCircle}
 		inline
 	>
 		<div className='es:w-full es:rounded-lg es:bg-gray-100 es:text-sm es:p-4'>
@@ -123,7 +124,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 ```jsx
 <BaseControl
 	label='Label'
-	icon={icons.emptyCircle}
+	icon={emptyCircle}
 	// highlight-next-line
 	inline
 >

--- a/website/ui-components/es-ui-components/block-icons.mdx
+++ b/website/ui-components/es-ui-components/block-icons.mdx
@@ -1,5 +1,9 @@
 # Block icons
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/icons)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { Button, InputField } from '@eightshift/ui-components';
 import { icons, blockIcons, BlockIcon } from '@eightshift/ui-components/icons';
@@ -24,25 +28,25 @@ Use within block manifests, or in your UI with the `<BlockIcon />` component.
 			data?.length > 0 ? k.toLowerCase().includes(data?.toLowerCase()) : true
 		);
 
-		if (filteredIcons.length < 1)  {
-			return (
-				<span>Nothing found</span>
-			);
-		}
+    	if (filteredIcons.length < 1)  {
+    		return (
+    			<span>Nothing found</span>
+    		);
+    	}
 
-		return filteredIcons.map((icon, index) => (
-			<Button
-				key={index}
-				className='esd-icon-showcase-button'
-				icon={<BlockIcon iconName={icon} />}
-				tooltip={<span className='es:font-mono'>{icon}</span>}
-				aria-label={icon}
-				onPress={() => {
-					navigator.clipboard.writeText(icon);
-				}}
-				type='simple'
-			/>
-		));
-	}}
+    	return filteredIcons.map((icon, index) => (
+    		<Button
+    			key={index}
+    			className='esd-icon-showcase-button'
+    			icon={<BlockIcon iconName={icon} />}
+    			tooltip={<span className='es:font-mono'>{icon}</span>}
+    			aria-label={icon}
+    			onPress={() => {
+    				navigator.clipboard.writeText(icon);
+    			}}
+    			type='simple'
+    		/>
+    	));
+    }}
 
 </ComponentShowcase>

--- a/website/ui-components/es-ui-components/breakpoint-preview.mdx
+++ b/website/ui-components/es-ui-components/breakpoint-preview.mdx
@@ -1,5 +1,9 @@
 # Breakpoint preview
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/breakpoint-preview)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { BreakpointPreview } from '@eightshift/ui-components';
 

--- a/website/ui-components/es-ui-components/breakpoint-preview.mdx
+++ b/website/ui-components/es-ui-components/breakpoint-preview.mdx
@@ -2,7 +2,6 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { BreakpointPreview } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
 
 <ComponentShowcase
 	className='es:text-sm'

--- a/website/ui-components/es-ui-components/button.mdx
+++ b/website/ui-components/es-ui-components/button.mdx
@@ -2,7 +2,7 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { Button, ButtonGroup, OptionSelect, Checkbox } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import { emptyCircle } from '@eightshift/ui-components/icons';
 
 :::note
 The click event is set by the `onPress` prop.
@@ -17,20 +17,20 @@ The click event is set by the `onPress` prop.
 ```
 
 <ComponentShowcase>
-	<Button icon={icons.emptyCircle} />
+	<Button icon={emptyCircle} />
 </ComponentShowcase>
 
 ```jsx
-<Button icon={icons.emptyCircle} />
+<Button icon={emptyCircle} />
 ```
 
 <ComponentShowcase>
-	<Button icon={icons.emptyCircle}>Hi, I'm a button!</Button>
+	<Button icon={emptyCircle}>Hi, I'm a button!</Button>
 </ComponentShowcase>
 
 ```jsx
 <Button
-	icon={icons.emptyCircle
+	icon={emptyCircle
 >
 	Hi, I'm a button!
 </Button>
@@ -54,7 +54,7 @@ If buttons are related, they can be grouped with a `ButtonGroup`.
 	<Button>First</Button>
 	<Button>Second</Button>
 	<Button>Third</Button>
-// highlight-next-line
+	// highlight-next-line
 </ButtonGroup>
 ```
 
@@ -115,11 +115,11 @@ For the complete list of props, use your IDE's autocomplete functionality.
 			<Button size={data}>Hi, I'm a button!</Button>
 			<Button
 				size={data}
-				icon={icons.emptyCircle}
+				icon={emptyCircle}
 			/>
 			<Button
 				size={data}
-				icon={icons.emptyCircle}
+				icon={emptyCircle}
 			>
 				Hi, I'm a button!
 			</Button>
@@ -162,11 +162,11 @@ For the complete list of props, use your IDE's autocomplete functionality.
 			<Button type={data}>Hi, I'm a button!</Button>
 			<Button
 				type={data}
-				icon={icons.emptyCircle}
+				icon={emptyCircle}
 			/>
 			<Button
 				type={data}
-				icon={icons.emptyCircle}
+				icon={emptyCircle}
 			>
 				Hi, I'm a button!
 			</Button>
@@ -187,14 +187,14 @@ For the complete list of props, use your IDE's autocomplete functionality.
 
 <ComponentShowcase>
 	<Button
-		icon={icons.emptyCircle}
+		icon={emptyCircle}
 		tooltip="Hi, I'm a tooltip!"
 	/>
 </ComponentShowcase>
 
 ```jsx
 <Button
-	icon={icons.emptyCircle}
+	icon={emptyCircle}
 	// highlight-next-line
 	tooltip="Hi, I'm a tooltip!"
 />
@@ -202,9 +202,10 @@ For the complete list of props, use your IDE's autocomplete functionality.
 
 :::note
 If text label is not set, please set the `aria-label` prop to ensure accessibility.
+
 <br />
-When `aria-label` is set, `tooltip` can be just passed without value. In that case it will take the value from `aria-label`.
-:::
+When `aria-label` is set, `tooltip` can be just passed without value. In that case it will take the value from
+`aria-label`. :::
 
 ### Pending
 
@@ -228,7 +229,10 @@ It will replace the button content with a loading indicator, announce an action,
 	)}
 >
 	{(data) => (
-		<Button pending={data.checked} onPress={() => alert('Button pressed!')}>
+		<Button
+			pending={data.checked}
+			onPress={() => alert('Button pressed!')}
+		>
 			Hi, I'm a button!
 		</Button>
 	)}

--- a/website/ui-components/es-ui-components/button.mdx
+++ b/website/ui-components/es-ui-components/button.mdx
@@ -1,5 +1,9 @@
 # Button
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/button)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { Button, ButtonGroup, OptionSelect, Checkbox } from '@eightshift/ui-components';
 import { emptyCircle } from '@eightshift/ui-components/icons';

--- a/website/ui-components/es-ui-components/checkbox.mdx
+++ b/website/ui-components/es-ui-components/checkbox.mdx
@@ -2,7 +2,7 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { Checkbox } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import { emptyRect } from '@eightshift/ui-components/icons';
 
 <ComponentShowcase defaultValue={false}>
 	{(data, setData) => {
@@ -34,7 +34,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 	{(data, setData) => {
 		return (
 			<Checkbox
-				icon={icons.emptyRect}
+				icon={emptyRect}
 				label='Demo'
 				checked={data}
 				onChange={setData}
@@ -46,7 +46,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 
 ```jsx
 <Checkbox
-	icon={icons.emptyRect}
+	icon={emptyRect}
 	label='Demo'
 	checked={data}
 	onChange={setData}

--- a/website/ui-components/es-ui-components/checkbox.mdx
+++ b/website/ui-components/es-ui-components/checkbox.mdx
@@ -1,5 +1,9 @@
 # Checkbox
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/checkbox)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { Checkbox } from '@eightshift/ui-components';
 import { emptyRect } from '@eightshift/ui-components/icons';

--- a/website/ui-components/es-ui-components/color-picker.mdx
+++ b/website/ui-components/es-ui-components/color-picker.mdx
@@ -1,5 +1,9 @@
 # Color picker
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/color-pickers)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { ColorPicker, OptionSelect } from '@eightshift/ui-components';
 

--- a/website/ui-components/es-ui-components/color-picker.mdx
+++ b/website/ui-components/es-ui-components/color-picker.mdx
@@ -2,7 +2,7 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { ColorPicker, OptionSelect } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+
 import { defaultColors, groupedColors } from './color-picker-helpers';
 
 <ComponentShowcase defaultValue='blue'>

--- a/website/ui-components/es-ui-components/color-swatch.mdx
+++ b/website/ui-components/es-ui-components/color-swatch.mdx
@@ -1,5 +1,9 @@
 # Color swatch
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/color-pickers)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { ColorSwatch } from '@eightshift/ui-components';
 

--- a/website/ui-components/es-ui-components/color-swatch.mdx
+++ b/website/ui-components/es-ui-components/color-swatch.mdx
@@ -2,7 +2,6 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { ColorSwatch } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
 
 <ComponentShowcase fitWidth>
 	<ColorSwatch color='#0D3636' />

--- a/website/ui-components/es-ui-components/column-config-slider.mdx
+++ b/website/ui-components/es-ui-components/column-config-slider.mdx
@@ -1,5 +1,9 @@
 # Column config slider
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/slider)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { ColumnConfigSlider } from '@eightshift/ui-components';
 import { columns } from '@eightshift/ui-components/icons';

--- a/website/ui-components/es-ui-components/column-config-slider.mdx
+++ b/website/ui-components/es-ui-components/column-config-slider.mdx
@@ -2,13 +2,13 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { ColumnConfigSlider } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import { columns } from '@eightshift/ui-components/icons';
 
 <ComponentShowcase defaultValue={[1, 12]}>
 	{(data, setData) => {
 		return (
 			<ColumnConfigSlider
-				icon={icons.columns}
+				icon={columns}
 				label='Column configuration'
 				value={data}
 				onChange={setData}
@@ -19,7 +19,7 @@ import { icons } from '@eightshift/ui-components/icons';
 
 ```jsx
 <ColumnConfigSlider
-	icon={icons.columns}
+	icon={columns}
 	label='Column configuration'
 	value={value} // e.g. [1, 12]
 	onChange={(value) => setData(value)}
@@ -36,7 +36,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 	{(data, setData) => {
 		return (
 			<ColumnConfigSlider
-				icon={icons.columns}
+				icon={columns}
 				label='Column configuration'
 				value={data}
 				onChange={setData}
@@ -48,7 +48,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 
 ```jsx
 <ColumnConfigSlider
-	icon={icons.columns}
+	icon={columns}
 	label='Column configuration'
 	value={value}
 	onChange={(value) => setData(value)}
@@ -63,7 +63,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 	{(data, setData) => {
 		return (
 			<ColumnConfigSlider
-				icon={icons.columns}
+				icon={columns}
 				label='Column configuration'
 				value={data}
 				onChange={setData}
@@ -76,7 +76,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 
 ```jsx
 <ColumnConfigSlider
-	icon={icons.columns}
+	icon={columns}
 	label='Column configuration'
 	value={value}
 	onChange={(value) => setData(value)}
@@ -92,7 +92,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 	{(data, setData) => {
 		return (
 			<ColumnConfigSlider
-				icon={icons.columns}
+				icon={columns}
 				label='Column configuration'
 				value={data}
 				onChange={setData}
@@ -104,7 +104,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 
 ```jsx
 <ColumnConfigSlider
-	icon={icons.columns}
+	icon={columns}
 	label='Column configuration'
 	value={value}
 	onChange={(value) => setData(value)}
@@ -119,7 +119,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 	{(data, setData) => {
 		return (
 			<ColumnConfigSlider
-				icon={icons.columns}
+				icon={columns}
 				label='Column configuration'
 				value={data}
 				onChange={setData}
@@ -131,7 +131,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 
 ```jsx
 <ColumnConfigSlider
-	icon={icons.columns}
+	icon={columns}
 	label='Column configuration'
 	value={value}
 	onChange={(value) => setData(value)}

--- a/website/ui-components/es-ui-components/component-toggle.mdx
+++ b/website/ui-components/es-ui-components/component-toggle.mdx
@@ -2,12 +2,12 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { ComponentToggle, OptionSelect } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import { paragraph } from '@eightshift/ui-components/icons';
 
 <ComponentShowcase>
 	{(data, setData) => (
 		<ComponentToggle
-			icon={icons.paragraph}
+			icon={paragraph}
 			label='Paragraph'
 			useComponent={data}
 			onChange={setData}
@@ -21,7 +21,7 @@ import { icons } from '@eightshift/ui-components/icons';
 
 ```jsx
 <ComponentToggle
-	icon={icons.paragraph}
+	icon={paragraph}
 	label='Paragraph'
 	useComponent={value}
 	onChange={(value) => setValue(value)}
@@ -39,7 +39,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 <ComponentShowcase defaultValue={true}>
 	{(data, setData) => (
 		<ComponentToggle
-			icon={icons.paragraph}
+			icon={paragraph}
 			label='Paragraph'
 			useComponent={data}
 			onChange={setData}
@@ -54,7 +54,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 
 ```jsx
 <ComponentToggle
-	icon={icons.paragraph}
+	icon={paragraph}
 	label='Paragraph'
 	useComponent={value}
 	onChange={(value) => setValue(value)}
@@ -70,7 +70,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 <ComponentShowcase>
 	{(data, setData) => (
 		<ComponentToggle
-			icon={icons.paragraph}
+			icon={paragraph}
 			label='Paragraph'
 			useComponent={data}
 			onChange={setData}
@@ -85,7 +85,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 
 ```jsx
 <ComponentToggle
-	icon={icons.paragraph}
+	icon={paragraph}
 	label='Paragraph'
 	useComponent={value}
 	onChange={(value) => setValue(value)}
@@ -117,7 +117,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 >
 	{(data, setData) => (
 		<ComponentToggle
-			icon={icons.paragraph}
+			icon={paragraph}
 			label='Paragraph'
 			useComponent={data.use}
 			onChange={(value) => setData({ ...data, use: value })}
@@ -132,7 +132,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 
 ```jsx
 <ComponentToggle
-	icon={icons.paragraph}
+	icon={paragraph}
 	label='Paragraph'
 	useComponent={value}
 	onChange={(value) => setValue(value)}

--- a/website/ui-components/es-ui-components/component-toggle.mdx
+++ b/website/ui-components/es-ui-components/component-toggle.mdx
@@ -1,5 +1,9 @@
 # Component toggle
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/component-toggle)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { ComponentToggle, OptionSelect } from '@eightshift/ui-components';
 import { paragraph } from '@eightshift/ui-components/icons';

--- a/website/ui-components/es-ui-components/container-panel.mdx
+++ b/website/ui-components/es-ui-components/container-panel.mdx
@@ -1,5 +1,9 @@
 # Container panel
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/container-panel)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { ContainerPanel, Checkbox, Button } from '@eightshift/ui-components';
 

--- a/website/ui-components/es-ui-components/container-panel.mdx
+++ b/website/ui-components/es-ui-components/container-panel.mdx
@@ -2,7 +2,6 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { ContainerPanel, Checkbox, Button } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
 
 A perfect shell for options within the Block editor sidebar. Replaces the default WordPress `<PanelBody>` component.
 

--- a/website/ui-components/es-ui-components/draggable-list-helpers.js
+++ b/website/ui-components/es-ui-components/draggable-list-helpers.js
@@ -8,22 +8,22 @@ import {
 	VStack,
 	HStack,
 } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import { emptyCircle, num1Circle, num2Circle, num3Circle } from '@eightshift/ui-components/icons';
 
 export const draggableListDefaultItems = [
 	{
 		toggle: false,
 		title: 'Item 1',
-		icon: icons.num1Circle,
+		icon: num1Circle,
 	},
 	{
 		toggle: true,
 		title: 'Item 2',
-		icon: icons.num2Circle,
+		icon: num2Circle,
 	},
 	{
 		toggle: true,
-		icon: icons.num3Circle,
+		icon: num3Circle,
 	},
 ];
 
@@ -40,7 +40,7 @@ export const DraggableListDemo = ({ data, setData, ...rest }) => {
 				return (
 					<DraggableListItem
 						label={title ?? 'New item'}
-						icon={icon ?? icons.emptyCircle}
+						icon={icon ?? emptyCircle}
 					>
 						<Switch
 							aria-label='Title'
@@ -71,7 +71,7 @@ export const DraggableDemo = ({ data, setData, ...rest }) => {
 							<DraggableHandle />
 
 							<RichLabel
-								icon={icon ?? icons.emptyCircle}
+								icon={icon ?? emptyCircle}
 								label={title ?? 'New item'}
 							/>
 						</HStack>

--- a/website/ui-components/es-ui-components/draggable-list.mdx
+++ b/website/ui-components/es-ui-components/draggable-list.mdx
@@ -1,7 +1,8 @@
 # Draggable list
 
 import { ComponentShowcase } from '../components/component-showcase';
-import { icons } from '@eightshift/ui-components/icons';
+import { emptyCircle } from '@eightshift/ui-components/icons';
+
 import { DraggableListDemo, draggableListDefaultItems } from './draggable-list-helpers';
 
 <ComponentShowcase defaultValue={draggableListDefaultItems}>
@@ -24,7 +25,7 @@ import { DraggableListDemo, draggableListDefaultItems } from './draggable-list-h
 		return (
 			<DraggableListItem
 				label={title ?? 'New item'}
-				icon={icon ?? icons.emptyCircle}
+				icon={icon ?? emptyCircle}
 			>
 				<Switch
 					aria-label='Title'

--- a/website/ui-components/es-ui-components/draggable-list.mdx
+++ b/website/ui-components/es-ui-components/draggable-list.mdx
@@ -1,5 +1,9 @@
 # Draggable list
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/draggable-list)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { emptyCircle } from '@eightshift/ui-components/icons';
 

--- a/website/ui-components/es-ui-components/draggable.mdx
+++ b/website/ui-components/es-ui-components/draggable.mdx
@@ -1,5 +1,9 @@
 # Draggable
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/draggable)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { emptyCircle } from '@eightshift/ui-components/icons';
 

--- a/website/ui-components/es-ui-components/draggable.mdx
+++ b/website/ui-components/es-ui-components/draggable.mdx
@@ -1,7 +1,8 @@
 # Draggable
 
 import { ComponentShowcase } from '../components/component-showcase';
-import { icons } from '@eightshift/ui-components/icons';
+import { emptyCircle } from '@eightshift/ui-components/icons';
+
 import { DraggableDemo, draggableListDefaultItems } from './draggable-list-helpers';
 
 <ComponentShowcase defaultValue={draggableListDefaultItems}>
@@ -30,7 +31,7 @@ import { DraggableDemo, draggableListDefaultItems } from './draggable-list-helpe
 
 				<RichLabel
 					label={title ?? 'New item'}
-					icon={icon ?? icons.emptyCircle}
+					icon={icon ?? emptyCircle}
 				/>
 
 				<Switch

--- a/website/ui-components/es-ui-components/expandable.mdx
+++ b/website/ui-components/es-ui-components/expandable.mdx
@@ -1,5 +1,9 @@
 # Expandable
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/expandable)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { Expandable, Button } from '@eightshift/ui-components';
 import { arrowDown, arrowUp, emptyCircle, emptyRect } from '@eightshift/ui-components/icons';

--- a/website/ui-components/es-ui-components/expandable.mdx
+++ b/website/ui-components/es-ui-components/expandable.mdx
@@ -2,11 +2,11 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { Expandable, Button } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import { arrowDown, arrowUp, emptyCircle, emptyRect } from '@eightshift/ui-components/icons';
 
 <ComponentShowcase defaultValue={false}>
 	<Expandable
-		icon={icons.emptyRect}
+		icon={emptyRect}
 		label='Expandable'
 		subtitle='Subtitle'
 	>
@@ -18,7 +18,7 @@ import { icons } from '@eightshift/ui-components/icons';
 
 ```jsx
 <Expandable
-	icon={icons.emptyRect}
+	icon={emptyRect}
 	label='Expandable'
 	subtitle='Subtitle'
 >
@@ -36,13 +36,13 @@ Add extra controls to the right of the label.
 
 <ComponentShowcase defaultValue={false}>
 	<Expandable
-		icon={icons.emptyRect}
+		icon={emptyRect}
 		label='Expandable'
 		subtitle='Subtitle'
 		actions={
 			<Button
 				size='small'
-				icon={icons.emptyCircle}
+				icon={emptyCircle}
 			/>
 		}
 	>
@@ -54,13 +54,13 @@ Add extra controls to the right of the label.
 
 ```jsx
 <Expandable
-	icon={icons.emptyRect}
+	icon={emptyRect}
 	label='Expandable'
 	subtitle='Subtitle'
 	// highlight-start
 	actions={
 		<Button
-			icon={icons.emptyCircle}
+			icon={emptyCircle}
 			size='small'
 			onPress={...}
 		/>
@@ -77,13 +77,13 @@ If you want to keep the actions visible even when the content is expanded, you c
 
 <ComponentShowcase defaultValue={false}>
 	<Expandable
-		icon={icons.emptyRect}
+		icon={emptyRect}
 		label='Expandable'
 		subtitle='Subtitle'
 		actions={
 			<Button
 				size='small'
-				icon={icons.emptyCircle}
+				icon={emptyCircle}
 			/>
 		}
 		keepActionsOnExpand
@@ -96,12 +96,12 @@ If you want to keep the actions visible even when the content is expanded, you c
 
 ```jsx
 <Expandable
-	icon={icons.emptyRect}
+	icon={emptyRect}
 	label='Expandable'
 	subtitle='Subtitle'
 	actions={
 		<Button
-			icon={icons.emptyCircle}
+			icon={emptyCircle}
 			onPress={...}
 		/>
 	}
@@ -119,7 +119,7 @@ If you want to disable this behavior, you can use the `noFocusHandling` prop.
 
 ```jsx
 <Expandable
-	icon={icons.emptyRect}
+	icon={emptyRect}
 	label='Expandable'
 	// highlight-next-line
 	noFocusHandling
@@ -141,12 +141,12 @@ The following props are provided:
 
 <ComponentShowcase defaultValue={false}>
 	<Expandable
-		icon={icons.emptyRect}
+		icon={emptyRect}
 		label='Expandable'
 		customOpenButton={({ open, toggleOpen, tooltip, disabled }) => (
 		<Button
 			size='small'
-			icon={open ? icons.arrowUp : icons.arrowDown}
+			icon={open ? arrowUp : arrowDown}
 			type='ghost'
 			onPress={toggleOpen}
 			disabled={disabled}
@@ -164,12 +164,12 @@ The following props are provided:
 
 ```jsx
 <Expandable
-	icon={icons.emptyRect}
+	icon={emptyRect}
 	label='Expandable'
 	// highlight-start
 	customOpenButton={({ open, toggleOpen, tooltip, disabled }) => (
 		<Button
-			icon={open ? icons.arrowUp : icons.arrowDown}
+			icon={open ? arrowUp : arrowDown}
 			onPress={toggleOpen}
 			type='ghost'
 			disabled={disabled}

--- a/website/ui-components/es-ui-components/gradient-editor.mdx
+++ b/website/ui-components/es-ui-components/gradient-editor.mdx
@@ -2,7 +2,6 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { GradientEditor } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
 
 <ComponentShowcase defaultValue='linear-gradient(30deg, #0D3636, #0D363600)'>
 	{(data, setData) => {

--- a/website/ui-components/es-ui-components/gradient-editor.mdx
+++ b/website/ui-components/es-ui-components/gradient-editor.mdx
@@ -1,5 +1,9 @@
 # Gradient editor
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/color-pickers)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { GradientEditor } from '@eightshift/ui-components';
 

--- a/website/ui-components/es-ui-components/input-field.mdx
+++ b/website/ui-components/es-ui-components/input-field.mdx
@@ -1,5 +1,9 @@
 # Input field
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/input-field)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { InputField, OptionSelect } from '@eightshift/ui-components';
 

--- a/website/ui-components/es-ui-components/input-field.mdx
+++ b/website/ui-components/es-ui-components/input-field.mdx
@@ -2,7 +2,6 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { InputField, OptionSelect } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
 
 <ComponentShowcase>
 	{(data, setData) => (

--- a/website/ui-components/es-ui-components/jsx-svg.mdx
+++ b/website/ui-components/es-ui-components/jsx-svg.mdx
@@ -1,5 +1,9 @@
 # JsxSvg
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/icons)
+:::
+
 Renders an SVG string as a real JSX SVG tree. Useful when an icon comes from a server response, a user-provided field, or any other place where you have SVG markup but not a React element.
 
 `JsxSvg` is exported from `@eightshift/ui-components/icons` and also has a dedicated subpath that pulls in only the renderer (and its parser dependency), without the rest of the icon bundle:

--- a/website/ui-components/es-ui-components/jsx-svg.mdx
+++ b/website/ui-components/es-ui-components/jsx-svg.mdx
@@ -1,0 +1,79 @@
+# JsxSvg
+
+Renders an SVG string as a real JSX SVG tree. Useful when an icon comes from a server response, a user-provided field, or any other place where you have SVG markup but not a React element.
+
+`JsxSvg` is exported from `@eightshift/ui-components/icons` and also has a dedicated subpath that pulls in only the renderer (and its parser dependency), without the rest of the icon bundle:
+
+```jsx
+import { JsxSvg } from '@eightshift/ui-components/icons';
+// or, lighter:
+import { JsxSvg } from '@eightshift/ui-components/jsx-svg';
+```
+
+## Basic usage
+
+```jsx
+const svg = '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">...</svg>';
+
+<JsxSvg svg={svg} />;
+```
+
+## Customizing the rendered SVG
+
+`className` is added to the root `<svg>` element:
+
+```jsx
+<JsxSvg
+	svg={svg}
+	className='es:text-accent-600 es:size-6'
+/>
+```
+
+`ariaHidden` (or `aria-hidden`) marks the SVG as decorative for assistive technology:
+
+```jsx
+<JsxSvg
+	svg={svg}
+	ariaHidden
+/>
+```
+
+## Dynamic props on the SVG
+
+If the SVG markup needs to react to component state, use `customProps` to inject JSX attributes and `customPropBindings` to map them to values.
+
+```jsx
+<JsxSvg
+	svg={svg}
+	customProps='className={demo}'
+	customPropBindings={{ demo: isActive ? 'es:text-accent-600' : 'es:text-surface-400' }}
+/>
+```
+
+## ID randomization
+
+SVGs with `id` attributes (gradients, filters, clip paths) can clash when the same SVG is rendered multiple times on a page. `JsxSvg` rewrites every `id` to a random value by default.
+
+| Prop                    | Description                                            |
+| ----------------------- | ------------------------------------------------------ |
+| `noIdRandomization`     | Set to `true` to keep the original `id` values.        |
+| `idRandomizationPrefix` | Prefix used for the rewritten IDs. Defaults to `icon`. |
+
+```jsx
+<JsxSvg
+	svg={svg}
+	idRandomizationPrefix='hero'
+/>
+```
+
+## Highlighted props
+
+| Prop                    | Description                                                                                   |
+| ----------------------- | --------------------------------------------------------------------------------------------- |
+| `svg`                   | SVG markup as a string. Required — if missing or not a string, the component renders nothing. |
+| `className`             | Class added to the root `<svg>`.                                                              |
+| `ariaHidden`            | Marks the SVG as decorative.                                                                  |
+| `customProps`           | Raw JSX attribute string injected into the root `<svg>`.                                      |
+| `customPropBindings`    | Object of values referenced by `customProps`.                                                 |
+| `noIdRandomization`     | Disable automatic `id` rewriting.                                                             |
+| `idRandomizationPrefix` | Prefix used when rewriting `id` attributes.                                                   |

--- a/website/ui-components/es-ui-components/link-input-helpers.js
+++ b/website/ui-components/es-ui-components/link-input-helpers.js
@@ -1,4 +1,4 @@
-import { icons } from '@eightshift/ui-components/icons';
+import { magicAltFillTransparent, newspaper, troubleshootAlt } from '@eightshift/ui-components/icons';
 
 const linkData = [
 	{ label: 'Eightshift', value: 'https://eightshift.com', metadata: { subtype: 'url' } },
@@ -57,15 +57,15 @@ export const getLinkData = async (searchTerm) => {
 
 export const getIconOverrides = (type) => {
 	if (type === 'page') {
-		return icons.magicAltFillTransparent;
+		return magicAltFillTransparent;
 	}
 
 	if (type === 'post') {
-		return icons.newspaper;
+		return newspaper;
 	}
 
 	if (type === 'help-article') {
-		return icons.troubleshootAlt;
+		return troubleshootAlt;
 	}
 
 	return null;

--- a/website/ui-components/es-ui-components/link-input.mdx
+++ b/website/ui-components/es-ui-components/link-input.mdx
@@ -2,7 +2,8 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { LinkInput } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import { magicAltFillTransparent, newspaper, troubleshootAlt } from '@eightshift/ui-components/icons';
+
 import { getLinkData, getIconOverrides } from './link-input-helpers';
 
 <ComponentShowcase defaultValue=''>
@@ -70,9 +71,9 @@ If you want to provide custom icons for the search suggestions, you can provide 
 
 ```jsx
 const overrides = {
-	post: icons.newspaper,
-	page: icons.magicAltFillTransparent,
-	'help-article': icons.troubleshootAlt,
+	post: newspaper,
+	page: magicAltFillTransparent,
+	'help-article': troubleshootAlt,
 };
 
 <LinkInput

--- a/website/ui-components/es-ui-components/link-input.mdx
+++ b/website/ui-components/es-ui-components/link-input.mdx
@@ -1,5 +1,9 @@
 # Link input
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/link-input)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { LinkInput } from '@eightshift/ui-components';
 import { magicAltFillTransparent, newspaper, troubleshootAlt } from '@eightshift/ui-components/icons';

--- a/website/ui-components/es-ui-components/matrix-align.mdx
+++ b/website/ui-components/es-ui-components/matrix-align.mdx
@@ -1,5 +1,9 @@
 # Matrix align
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/matrix-align)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { MatrixAlign } from '@eightshift/ui-components';
 import { emptyRect } from '@eightshift/ui-components/icons';

--- a/website/ui-components/es-ui-components/matrix-align.mdx
+++ b/website/ui-components/es-ui-components/matrix-align.mdx
@@ -2,7 +2,7 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { MatrixAlign } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import { emptyRect } from '@eightshift/ui-components/icons';
 
 <ComponentShowcase defaultValue='center center'>
 	{(data, setData) => (
@@ -53,7 +53,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 			onChange={setData}
 			value={data}
 			label='Alignment'
-			icon={icons.emptyRect}
+			icon={emptyRect}
 		/>
 	)}
 </ComponentShowcase>
@@ -64,7 +64,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 	value={data}
 	// highlight-start
 	label='Alignment'
-	icon={icons.emptyRect}
+	icon={emptyRect}
 	// highlight-end
 />
 ```

--- a/website/ui-components/es-ui-components/menu.mdx
+++ b/website/ui-components/es-ui-components/menu.mdx
@@ -1,5 +1,9 @@
 # Menu
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/menu)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { Menu, MenuItem, MenuSeparator, MenuSection, SubMenuItem } from '@eightshift/ui-components';
 import { bold, emptyCircle, emptyRect } from '@eightshift/ui-components/icons';

--- a/website/ui-components/es-ui-components/menu.mdx
+++ b/website/ui-components/es-ui-components/menu.mdx
@@ -2,7 +2,7 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { Menu, MenuItem, MenuSeparator, MenuSection, SubMenuItem } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import { bold, emptyCircle, emptyRect } from '@eightshift/ui-components/icons';
 
 <ComponentShowcase>
 	<Menu>
@@ -110,10 +110,10 @@ If you need to have a top-level menu item outside of any sections you can either
 <ComponentShowcase>
 	<Menu>
 		<MenuSection label='Icon'>
-			<MenuItem icon={icons.emptyCircle}>First item</MenuItem>
+			<MenuItem icon={emptyCircle}>First item</MenuItem>
 		</MenuSection>
 		<MenuSection label='End icon'>
-			<MenuItem endIcon={icons.emptyRect}>First item</MenuItem>
+			<MenuItem endIcon={emptyRect}>First item</MenuItem>
 		</MenuSection>
 		<MenuSection label='Additional text'>
 			<MenuItem shortcut='Ctrl + Z'>Second item</MenuItem>
@@ -129,13 +129,13 @@ If you need to have a top-level menu item outside of any sections you can either
 <Menu>
 	<MenuItem
 		// highlight-next-line
-		icon={icons.emptyCircle}
+		icon={emptyCircle}
 	>
 		Item with icon
 	</MenuItem>
 	<MenuItem
 		// highlight-next-line
-		endIcon={icons.emptyRect}
+		endIcon={emptyRect}
 	>
 		Item with end icon
 	</MenuItem>
@@ -272,7 +272,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 <ComponentShowcase>
 	<Menu
 		triggerLabel='Menu'
-		triggerIcon={icons.emptyCircle}
+		triggerIcon={emptyCircle}
 	>
 		<MenuItem>First item</MenuItem>
 		<MenuItem>Second item</MenuItem>
@@ -284,7 +284,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 <Menu
 	// highlight-start
 	triggerLabel='Menu'
-	triggerIcon={icons.emptyCircle}
+	triggerIcon={emptyCircle}
 	// highlight-end
 >
 	<MenuItem>First item</MenuItem>
@@ -395,7 +395,7 @@ This allows implementing a button that can, for example, act as a toggle button 
 >
 	{(data, setData) => (
 		<Menu
-			triggerIcon={icons.bold}
+			triggerIcon={bold}
 			tooltip='Font weight'
 			triggerProps={{
 				type: data === '700' ? 'selected' : 'default',
@@ -435,7 +435,7 @@ _Click to toggle 'bold', press and hold for more font weights._
 
 ```jsx
 <Menu
-	triggerIcon={icons.bold}
+	triggerIcon={bold}
 	tooltip='Font weight'
 	triggerProps={{
 		type: fontWeight === '700' ? 'selected' : 'default',

--- a/website/ui-components/es-ui-components/modal.mdx
+++ b/website/ui-components/es-ui-components/modal.mdx
@@ -1,5 +1,9 @@
 # Modal
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/modal)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { Modal, Button } from '@eightshift/ui-components';
 import { experiment, pointerHand, trash } from '@eightshift/ui-components/icons';

--- a/website/ui-components/es-ui-components/modal.mdx
+++ b/website/ui-components/es-ui-components/modal.mdx
@@ -2,7 +2,7 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { Modal, Button } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import { experiment, pointerHand, trash } from '@eightshift/ui-components/icons';
 
 <ComponentShowcase>
 	<Modal>
@@ -27,7 +27,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 <ComponentShowcase>
 	<Modal
 		triggerLabel='Click me'
-		triggerIcon={icons.pointerHand}
+		triggerIcon={pointerHand}
 	>
 		<div className='es:w-full es:rounded-xl es:bg-gray-100 es:text-sm es:p-4 es:min-h-40'>
 			<span>This is demo content</span>
@@ -39,7 +39,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 <Modal
 	// highlight-start
 	triggerLabel='Click me'
-	triggerIcon={icons.pointerHand}
+	triggerIcon={pointerHand}
 	// highlight-end
 >
 	<div>This is demo content</div>
@@ -52,7 +52,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 
 <ComponentShowcase>
 	<Modal
-		triggerIcon={icons.trash}
+		triggerIcon={trash}
 		triggerProps={{ type: 'danger' }}
 		contentClassName='es:p-4'
 		noCloseButton
@@ -71,7 +71,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 
 ```jsx
 <Modal
-	triggerIcon={icons.trash}
+	triggerIcon={trash}
 	// highlight-next-line
 	triggerProps={{ type: 'danger' }}
 >
@@ -166,7 +166,7 @@ You can add actions to the header of the modal with the `headerActions` prop.
 			<Button
 				type='selectedGhost'
 				size='small'
-				icon={icons.experiment}
+				icon={experiment}
 				aria-label='Demo button'
 				onPress={() => alert('Demo button clicked')}
 			/>
@@ -186,7 +186,7 @@ You can add actions to the header of the modal with the `headerActions` prop.
 		<Button
 			type='ghost'
 			size='small'
-			icon={icons.experiment}
+			icon={experiment}
 			aria-label='Demo button'
 			onPress={() => alert('Demo button clicked')}
 		/>
@@ -245,7 +245,7 @@ so it can automatically wire up the modal's open/close functionality.
 <ComponentShowcase>
 	<Modal
 		customTrigger={
-			<Button type='ghost' icon={icons.pointerHand}>Click me</Button>
+			<Button type='ghost' icon={pointerHand}>Click me</Button>
 		}
 	>
 		<div className='es:w-full es:rounded-xl es:bg-gray-100 es:text-sm es:p-4 es:min-h-40'>
@@ -260,7 +260,7 @@ so it can automatically wire up the modal's open/close functionality.
 	customTrigger={
 		<Button
 			type='ghost'
-			icon={icons.pointerHand}
+			icon={pointerHand}
 		>
 			Click me
 		</Button>

--- a/website/ui-components/es-ui-components/multi-select.mdx
+++ b/website/ui-components/es-ui-components/multi-select.mdx
@@ -2,7 +2,7 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { MultiSelect } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+
 import { demoOptions } from './select-helpers';
 
 <ComponentShowcase defaultValue={[]}>

--- a/website/ui-components/es-ui-components/multi-select.mdx
+++ b/website/ui-components/es-ui-components/multi-select.mdx
@@ -1,5 +1,9 @@
 # Multi-select
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/select)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { MultiSelect } from '@eightshift/ui-components';
 

--- a/website/ui-components/es-ui-components/notice.mdx
+++ b/website/ui-components/es-ui-components/notice.mdx
@@ -1,5 +1,9 @@
 # Notice
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/notice)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { Notice, OptionSelect, Checkbox } from '@eightshift/ui-components';
 import { magicAltFillTransparent } from '@eightshift/ui-components/icons';

--- a/website/ui-components/es-ui-components/notice.mdx
+++ b/website/ui-components/es-ui-components/notice.mdx
@@ -2,7 +2,7 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { Notice, OptionSelect, Checkbox } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import { magicAltFillTransparent } from '@eightshift/ui-components/icons';
 
 <ComponentShowcase>
 	<Notice
@@ -76,7 +76,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 		label='Warning'
 		subtitle='Potential magic ahead'
 		type='warning'
-		icon={icons.magicAltFillTransparent}
+		icon={magicAltFillTransparent}
 	/>
 </ComponentShowcase>
 
@@ -86,7 +86,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 	subtitle='Potential magic ahead'
 	type='warning'
 	// highlight-next-line
-	icon={icons.magicAltFillTransparent}
+	icon={magicAltFillTransparent}
 />
 ```
 

--- a/website/ui-components/es-ui-components/number-picker.mdx
+++ b/website/ui-components/es-ui-components/number-picker.mdx
@@ -1,5 +1,9 @@
 # Number picker
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/number-picker)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { NumberPicker, Button } from '@eightshift/ui-components';
 import { emptyCircle, resetToZero } from '@eightshift/ui-components/icons';

--- a/website/ui-components/es-ui-components/number-picker.mdx
+++ b/website/ui-components/es-ui-components/number-picker.mdx
@@ -2,7 +2,7 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { NumberPicker, Button } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import { emptyCircle, resetToZero } from '@eightshift/ui-components/icons';
 
 <ComponentShowcase defaultValue={0}>
 	{(data, setData) => (
@@ -134,7 +134,7 @@ Decimal numbers are allowed.
 			onChange={setData}
 		>
 			<Button
-				icon={icons.resetToZero}
+				icon={resetToZero}
 				tooltip='Reset'
 				onPress={() => setData(0)}
 				disabled={data === 0}
@@ -152,7 +152,7 @@ Decimal numbers are allowed.
 >
 	// highlight-start
 	<Button
-		icon={icons.resetToZero}
+		icon={resetToZero}
 		tooltip='Reset'
 		onPress={() => setValue(0)}
 		disabled={value === 0}
@@ -170,7 +170,7 @@ Decimal numbers are allowed.
 			value={data}
 			onChange={setData}
 			label='Pick a number'
-			icon={icons.emptyCircle}
+			icon={emptyCircle}
 			help='Help text'
 		/>
 	)}
@@ -182,7 +182,7 @@ Decimal numbers are allowed.
 	onChange={(value) => setValue(value)}
 	// highlight-start
 	label='Pick a number'
-	icon={icons.emptyCircle}
+	icon={emptyCircle}
 	help='Help text'
 	// highlight-end
 />
@@ -194,7 +194,7 @@ Decimal numbers are allowed.
 			value={data}
 			onChange={setData}
 			label='Pick a number'
-			icon={icons.emptyCircle}
+			icon={emptyCircle}
 			subtitle='Subtitle text'
 			inline
 		/>
@@ -207,7 +207,7 @@ Decimal numbers are allowed.
 	onChange={(value) => setValue(value)}
 	// highlight-start
 	label='Pick a number'
-	icon={icons.emptyCircle}
+	icon={emptyCircle}
 	subtitle='Subtitle text'
 	inline
 	// highlight-end

--- a/website/ui-components/es-ui-components/option-select.mdx
+++ b/website/ui-components/es-ui-components/option-select.mdx
@@ -1,5 +1,9 @@
 # Option selector
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/option-select)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { OptionSelect, Checkbox, Button, Menu, MenuItem, MenuSeparator } from '@eightshift/ui-components';
 import {

--- a/website/ui-components/es-ui-components/option-select.mdx
+++ b/website/ui-components/es-ui-components/option-select.mdx
@@ -2,7 +2,18 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { OptionSelect, Checkbox, Button, Menu, MenuItem, MenuSeparator } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import {
+	columns,
+	design,
+	emptyCircle,
+	emptyRect,
+	large,
+	magicAlt,
+	medium,
+	multiple,
+	small,
+	wrench,
+} from '@eightshift/ui-components/icons';
 
 This is a versatile component that can allow selecting from a set of options in various ways.
 
@@ -25,7 +36,7 @@ This is a versatile component that can allow selecting from a set of options in 
 
 ```jsx
 <OptionSelect
-	icon={icons.columns}
+	icon={columns}
 	label='Option'
 	value={value} // e.g. 'option1'
 	onChange={(value) => setData(value)}
@@ -55,9 +66,9 @@ For the complete list of props, use your IDE's autocomplete functionality.
 				value={data}
 				onChange={setData}
 				options={[
-					{ value: 'option1', label: 'Option 1', icon: icons.design },
-					{ value: 'option2', label: 'Option 2', icon: icons.wrench },
-					{ value: 'option3', label: 'Option 3', icon: icons.magicAlt },
+					{ value: 'option1', label: 'Option 1', icon: design },
+					{ value: 'option2', label: 'Option 2', icon: wrench },
+					{ value: 'option3', label: 'Option 3', icon: magicAlt },
 				]}
 				type='toggleButtons'
 			/>
@@ -77,9 +88,9 @@ For the complete list of props, use your IDE's autocomplete functionality.
 				value={data}
 				onChange={setData}
 				options={[
-					{ value: 'option1', label: 'Option 1', icon: icons.design },
-					{ value: 'option2', label: 'Option 2', icon: icons.wrench },
-					{ value: 'option3', label: 'Option 3', icon: icons.magicAlt },
+					{ value: 'option1', label: 'Option 1', icon: design },
+					{ value: 'option2', label: 'Option 2', icon: wrench },
+					{ value: 'option3', label: 'Option 3', icon: magicAlt },
 				]}
 				type='toggleButtonsSplit'
 			/>
@@ -147,9 +158,9 @@ For the complete list of props, use your IDE's autocomplete functionality.
 				value={data}
 				onChange={setData}
 				options={[
-					{ value: 'option1', label: 'Option 1', icon: icons.design },
-					{ value: 'option2', label: 'Option 2', icon: icons.wrench },
-					{ value: 'option3', label: 'Option 3', icon: icons.magicAlt },
+					{ value: 'option1', label: 'Option 1', icon: design },
+					{ value: 'option2', label: 'Option 2', icon: wrench },
+					{ value: 'option3', label: 'Option 3', icon: magicAlt },
 				]}
 				type='menu'
 			/>
@@ -169,9 +180,9 @@ For the complete list of props, use your IDE's autocomplete functionality.
 				value={data}
 				onChange={setData}
 				options={[
-					{ value: 'option1', label: 'Option 1', endIcon: icons.design },
-					{ value: 'option2', label: 'Option 2', endIcon: icons.wrench },
-					{ value: 'option3', label: 'Option 3', endIcon: icons.magicAlt },
+					{ value: 'option1', label: 'Option 1', endIcon: design },
+					{ value: 'option2', label: 'Option 2', endIcon: wrench },
+					{ value: 'option3', label: 'Option 3', endIcon: magicAlt },
 				]}
 				type='menu'
 			/>
@@ -190,9 +201,9 @@ For the complete list of props, use your IDE's autocomplete functionality.
 				onChange={setData}
 				options={[
 					{ value: '-', label: 'Try and click me', disabled: true },
-					{ value: 'option1', label: 'Option 1', endIcon: icons.design },
-					{ value: 'option2', label: 'Option 2', endIcon: icons.wrench },
-					{ value: 'option3', label: 'Option 3', endIcon: icons.magicAlt },
+					{ value: 'option1', label: 'Option 1', endIcon: design },
+					{ value: 'option2', label: 'Option 2', endIcon: wrench },
+					{ value: 'option3', label: 'Option 3', endIcon: magicAlt },
 				]}
 				type='menu'
 			/>
@@ -210,9 +221,9 @@ Separator lines <br /> (`separator: 'below'` or `separator: 'above'`)
 				value={data}
 				onChange={setData}
 				options={[
-					{ value: 'option1', label: 'Option 1', endIcon: icons.design, separator: 'below' },
-					{ value: 'option2', label: 'Option 2', endIcon: icons.wrench },
-					{ value: 'option3', label: 'Option 3', endIcon: icons.magicAlt, separator: 'above' },
+					{ value: 'option1', label: 'Option 1', endIcon: design, separator: 'below' },
+					{ value: 'option2', label: 'Option 2', endIcon: wrench },
+					{ value: 'option3', label: 'Option 3', endIcon: magicAlt, separator: 'above' },
 				]}
 				type='menu'
 			/>
@@ -300,9 +311,9 @@ Most item features from `'menu'` are supported.
 					value={data}
 					onChange={setData}
 					options={[
-						{ value: 'option1', label: 'Option 1', icon: icons.design },
-						{ value: 'option2', label: 'Option 2', icon: icons.wrench },
-						{ value: 'option3', label: 'Option 3', icon: icons.magicAlt },
+						{ value: 'option1', label: 'Option 1', icon: design },
+						{ value: 'option2', label: 'Option 2', icon: wrench },
+						{ value: 'option3', label: 'Option 3', icon: magicAlt },
 					]}
 					type='submenu'
 				/>
@@ -321,9 +332,9 @@ Most item features from `'menu'` are supported.
 		value={data}
 		onChange={setData}
 		options={[
-			{ value: 'option1', label: 'Option 1', icon: icons.design },
-			{ value: 'option2', label: 'Option 2', icon: icons.wrench },
-			{ value: 'option3', label: 'Option 3', icon: icons.magicAlt },
+			{ value: 'option1', label: 'Option 1', icon: design },
+			{ value: 'option2', label: 'Option 2', icon: wrench },
+			{ value: 'option3', label: 'Option 3', icon: magicAlt },
 		]}
 		type='submenu'
 	/>
@@ -342,13 +353,13 @@ If no `label` is provided, the current value will be used as a label.
 				<MenuItem>Ipsum</MenuItem>
 				<MenuSeparator />
 				<OptionSelect
-					icon={icons.multiple}
+					icon={multiple}
 					value={data}
 					onChange={setData}
 					options={[
-						{ value: 'option1', label: 'Option 1', icon: icons.design },
-						{ value: 'option2', label: 'Option 2', icon: icons.wrench },
-						{ value: 'option3', label: 'Option 3', icon: icons.magicAlt },
+						{ value: 'option1', label: 'Option 1', icon: design },
+						{ value: 'option2', label: 'Option 2', icon: wrench },
+						{ value: 'option3', label: 'Option 3', icon: magicAlt },
 					]}
 					type='submenu'
 				/>
@@ -367,15 +378,15 @@ If `subtitle` is set (to `true`), the current value will be used as a subtitle.
 				<MenuItem>Ipsum</MenuItem>
 				<MenuSeparator />
 				<OptionSelect
-					icon={icons.multiple}
+					icon={multiple}
 					label='Option'
 					subtitle
 					value={data}
 					onChange={setData}
 					options={[
-						{ value: 'option1', label: 'Option 1', icon: icons.design },
-						{ value: 'option2', label: 'Option 2', icon: icons.wrench },
-						{ value: 'option3', label: 'Option 3', icon: icons.magicAlt },
+						{ value: 'option1', label: 'Option 1', icon: design },
+						{ value: 'option2', label: 'Option 2', icon: wrench },
+						{ value: 'option3', label: 'Option 3', icon: magicAlt },
 					]}
 					type='submenu'
 				/>
@@ -404,9 +415,9 @@ Most item features from `'menu'` are supported.
 					value={data}
 					onChange={setData}
 					options={[
-						{ value: 'option1', label: 'Option 1', icon: icons.design },
-						{ value: 'option2', label: 'Option 2', icon: icons.wrench },
-						{ value: 'option3', label: 'Option 3', icon: icons.magicAlt },
+						{ value: 'option1', label: 'Option 1', icon: design },
+						{ value: 'option2', label: 'Option 2', icon: wrench },
+						{ value: 'option3', label: 'Option 3', icon: magicAlt },
 					]}
 					type='standaloneMenuItems'
 				/>
@@ -425,9 +436,9 @@ Most item features from `'menu'` are supported.
 		value={data}
 		onChange={setData}
 		options={[
-			{ value: 'option1', label: 'Option 1', icon: icons.design },
-			{ value: 'option2', label: 'Option 2', icon: icons.wrench },
-			{ value: 'option3', label: 'Option 3', icon: icons.magicAlt },
+			{ value: 'option1', label: 'Option 1', icon: design },
+			{ value: 'option2', label: 'Option 2', icon: wrench },
+			{ value: 'option3', label: 'Option 3', icon: magicAlt },
 		]}
 		type='standaloneMenuItems'
 	/>
@@ -446,9 +457,9 @@ _(not applicable to all types)_
 				value={data}
 				onChange={setData}
 				options={[
-					{ value: 'option1', label: 'Small', icon: icons.small },
-					{ value: 'option2', label: 'Medium', icon: icons.medium },
-					{ value: 'option3', label: 'Large', icon: icons.large },
+					{ value: 'option1', label: 'Small', icon: small },
+					{ value: 'option2', label: 'Medium', icon: medium },
+					{ value: 'option3', label: 'Large', icon: large },
 				]}
 				type='radios'
 				vertical
@@ -459,7 +470,7 @@ _(not applicable to all types)_
 
 ```jsx
 <OptionSelect
-	icon={icons.columns}
+	icon={columns}
 	label='Option'
 	value={value} // e.g. 'option1'
 	onChange={(value) => setData(value)}
@@ -487,9 +498,9 @@ Hide the trigger icon with `noTriggerIcon`.
 				value={data}
 				onChange={setData}
 				options={[
-					{ value: 'option1', label: 'Small', icon: icons.small },
-					{ value: 'option2', label: 'Medium', icon: icons.medium },
-					{ value: 'option3', label: 'Large', icon: icons.large },
+					{ value: 'option1', label: 'Small', icon: small },
+					{ value: 'option2', label: 'Medium', icon: medium },
+					{ value: 'option3', label: 'Large', icon: large },
 				]}
 				type='menu'
 				noTriggerIcon
@@ -508,9 +519,9 @@ Hide the trigger label with `noTriggerLabel`.
 				value={data}
 				onChange={setData}
 				options={[
-					{ value: 'option1', label: 'Small', icon: icons.small },
-					{ value: 'option2', label: 'Medium', icon: icons.medium },
-					{ value: 'option3', label: 'Large', icon: icons.large },
+					{ value: 'option1', label: 'Small', icon: small },
+					{ value: 'option2', label: 'Medium', icon: medium },
+					{ value: 'option3', label: 'Large', icon: large },
 				]}
 				type='menu'
 				noTriggerLabel
@@ -530,9 +541,9 @@ Modify the "outside" component props with `wrapperProps`.
 					value={data}
 					onChange={setData}
 					options={[
-						{ value: 'option1', label: 'Option 1', icon: icons.emptyCircle },
-						{ value: 'option2', label: 'Option 2', icon: icons.emptyRect },
-						{ value: 'option3', label: 'Option 3', icon: icons.emptyCircle },
+						{ value: 'option1', label: 'Option 1', icon: emptyCircle },
+						{ value: 'option2', label: 'Option 2', icon: emptyRect },
+						{ value: 'option3', label: 'Option 3', icon: emptyCircle },
 					]}
 					wrapperProps={{ className: 'es:bg-secondary-100 es:p-2' }}
 				/>
@@ -542,9 +553,9 @@ Modify the "outside" component props with `wrapperProps`.
     				value={data}
     				onChange={setData}
     				options={[
-    					{ value: 'option1', label: 'Option 1', icon: icons.emptyCircle },
-    					{ value: 'option2', label: 'Option 2', icon: icons.emptyRect },
-    					{ value: 'option3', label: 'Option 3', icon: icons.emptyCircle },
+    					{ value: 'option1', label: 'Option 1', icon: emptyCircle },
+    					{ value: 'option2', label: 'Option 2', icon: emptyRect },
+    					{ value: 'option3', label: 'Option 3', icon: emptyCircle },
     				]}
     				type='radios'
     				wrapperProps={{ className: 'es:bg-secondary-100 es:p-2' }}
@@ -555,9 +566,9 @@ Modify the "outside" component props with `wrapperProps`.
     				value={data}
     				onChange={setData}
     				options={[
-    					{ value: 'option1', label: 'Option 1', icon: icons.emptyCircle },
-    					{ value: 'option2', label: 'Option 2', icon: icons.emptyRect },
-    					{ value: 'option3', label: 'Option 3', icon: icons.emptyCircle },
+    					{ value: 'option1', label: 'Option 1', icon: emptyCircle },
+    					{ value: 'option2', label: 'Option 2', icon: emptyRect },
+    					{ value: 'option3', label: 'Option 3', icon: emptyCircle },
     				]}
     				type='menu'
     				wrapperProps={{ className: 'es:bg-accent-50 es:p-2' }}
@@ -590,9 +601,9 @@ Hide the item icon with `noItemIcon`.
 				value={data}
 				onChange={setData}
 				options={[
-					{ value: 'option1', label: 'Small', icon: icons.small },
-					{ value: 'option2', label: 'Medium', icon: icons.medium },
-					{ value: 'option3', label: 'Large', icon: icons.large },
+					{ value: 'option1', label: 'Small', icon: small },
+					{ value: 'option2', label: 'Medium', icon: medium },
+					{ value: 'option3', label: 'Large', icon: large },
 				]}
 				type='menu'
 				noItemIcon
@@ -611,9 +622,9 @@ Hide the item label with `noItemLabel`.
 				value={data}
 				onChange={setData}
 				options={[
-					{ value: 'option1', label: 'Small', icon: icons.small },
-					{ value: 'option2', label: 'Medium', icon: icons.medium },
-					{ value: 'option3', label: 'Large', icon: icons.large },
+					{ value: 'option1', label: 'Small', icon: small },
+					{ value: 'option2', label: 'Medium', icon: medium },
+					{ value: 'option3', label: 'Large', icon: large },
 				]}
 				noItemLabel
 			/>
@@ -631,9 +642,9 @@ Modify the item props with `itemProps` or just pass a class name with `itemClass
 				value={data}
 				onChange={setData}
 				options={[
-					{ value: 'option1', label: 'Small', icon: icons.small },
-					{ value: 'option2', label: 'Medium', icon: icons.medium },
-					{ value: 'option3', label: 'Large', icon: icons.large },
+					{ value: 'option1', label: 'Small', icon: small },
+					{ value: 'option2', label: 'Medium', icon: medium },
+					{ value: 'option3', label: 'Large', icon: large },
 				]}
 				itemProps={{ size: 'large' }}
 				itemClassName='es:flex-col esd-btn-custom'

--- a/website/ui-components/es-ui-components/options-panel.mdx
+++ b/website/ui-components/es-ui-components/options-panel.mdx
@@ -2,7 +2,7 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { OptionsPanel, OptionsPanelSection, OptionsPanelHeader, Button } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import { save } from '@eightshift/ui-components/icons';
 
 An elegant way to display options in an options page, with a contained width and options for label and help text.
 
@@ -105,9 +105,7 @@ To augment the `OptionsPanel`s, you can add an `OptionsPanelHeader` to nicely di
 </ComponentShowcase>
 
 ```jsx
-<OptionsPanelHeader
-	title='Global settings'
-/>
+<OptionsPanelHeader title='Global settings' />
 ```
 
 You can also add `actions` to the right.
@@ -118,7 +116,7 @@ You can also add `actions` to the right.
 >
 	<OptionsPanelHeader
 		title='Global settings'
-		actions={<Button icon={icons.save}>Save</Button>}
+		actions={<Button icon={save}>Save</Button>}
 	/>
 </ComponentShowcase>
 
@@ -126,9 +124,7 @@ You can also add `actions` to the right.
 <OptionsPanelHeader
 	title='Global settings'
 	// highlight-start
-	actions={
-		<Button icon={icons.save}>Save</Button>
-	}
+	actions={<Button icon={save}>Save</Button>}
 	// highlight-end
 />
 ```
@@ -139,20 +135,12 @@ Additional content can be added below the title by passing it as children.
 	className='es:bg-gray-50 es:w-full'
 	fitWidth
 >
-	<OptionsPanelHeader
-		title='Global settings'
-	>
-		Lorem ipsum dolor sit amet.
-	</OptionsPanelHeader>
+	<OptionsPanelHeader title='Global settings'>Lorem ipsum dolor sit amet.</OptionsPanelHeader>
 </ComponentShowcase>
 
 ```jsx
-<OptionsPanelHeader
-	title='Global settings'
->
-	// highlight-start
-	Lorem ipsum dolor sit amet.
-	// highlight-end
+<OptionsPanelHeader title='Global settings'>
+	// highlight-start Lorem ipsum dolor sit amet. // highlight-end
 </OptionsPanelHeader>
 ```
 

--- a/website/ui-components/es-ui-components/options-panel.mdx
+++ b/website/ui-components/es-ui-components/options-panel.mdx
@@ -1,5 +1,9 @@
 # Options panel
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/options-panel)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { OptionsPanel, OptionsPanelSection, OptionsPanelHeader, Button } from '@eightshift/ui-components';
 import { save } from '@eightshift/ui-components/icons';

--- a/website/ui-components/es-ui-components/placeholders.mdx
+++ b/website/ui-components/es-ui-components/placeholders.mdx
@@ -1,5 +1,9 @@
 # Placeholders
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/placeholders)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import {
 	ImagePlaceholder,

--- a/website/ui-components/es-ui-components/placeholders.mdx
+++ b/website/ui-components/es-ui-components/placeholders.mdx
@@ -9,7 +9,7 @@ import {
 	OptionSelect,
 	RichLabel,
 } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import { a11yWarning, experiment, file, magicAlt } from '@eightshift/ui-components/icons';
 
 For the complete list of props, use your IDE's autocomplete functionality.
 
@@ -158,14 +158,14 @@ a bit more performant as you don't have an `<img>` without a source.
 <ComponentShowcase>
 	<FilePlaceholder
 		fileName='demo.json'
-		icon={icons.file}
+		icon={file}
 	/>
 </ComponentShowcase>
 
 ```jsx
 <FilePlaceholder
 	fileName='demo.json'
-	icon={icons.file}
+	icon={file}
 />
 ```
 
@@ -174,18 +174,18 @@ a bit more performant as you don't have an `<img>` without a source.
 `style` and `size` works the same as in the `ImagePlaceholder`, so they won't be covered again.
 
 <ComponentShowcase>
-	<MediaPlaceholder icon={icons.magicAlt} />
+	<MediaPlaceholder icon={magicAlt} />
 </ComponentShowcase>
 
 ```jsx
-<MediaPlaceholder icon={icons.magicAlt} />
+<MediaPlaceholder icon={magicAlt} />
 ```
 
 ### Help text
 
 <ComponentShowcase>
 	<MediaPlaceholder
-		icon={icons.experiment}
+		icon={experiment}
 		style='simple'
 		size='large'
 		helpText='Lorem ipsum dolor.'
@@ -194,7 +194,7 @@ a bit more performant as you don't have an `<img>` without a source.
 
 ```jsx
 <MediaPlaceholder
-	icon={icons.experiment}
+	icon={experiment}
 	style='simple'
 	size='large'
 	// highlight-next-line
@@ -204,12 +204,12 @@ a bit more performant as you don't have an `<img>` without a source.
 
 <ComponentShowcase>
 	<MediaPlaceholder
-		icon={icons.experiment}
+		icon={experiment}
 		style='simple'
 		size='large'
 		helpText={
 			<RichLabel
-				icon={icons.a11yWarning}
+				icon={a11yWarning}
 				label='Lorem ipsum dolor.'
 			/>
 		}
@@ -218,13 +218,13 @@ a bit more performant as you don't have an `<img>` without a source.
 
 ```jsx
 <MediaPlaceholder
-	icon={icons.experiment}
+	icon={experiment}
 	style='simple'
 	size='large'
 	// highlight-start
 	helpText={
 		<RichLabel
-			icon={icons.a11yWarning}
+			icon={a11yWarning}
 			label='Lorem ipsum dolor.'
 		/>
 	}

--- a/website/ui-components/es-ui-components/radio-button.mdx
+++ b/website/ui-components/es-ui-components/radio-button.mdx
@@ -2,7 +2,6 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { RadioButton, RadioButtonGroup } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
 
 <ComponentShowcase defaultValue='first'>
 	{(data, setData) => {

--- a/website/ui-components/es-ui-components/radio-button.mdx
+++ b/website/ui-components/es-ui-components/radio-button.mdx
@@ -1,5 +1,9 @@
 # Radio button
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/radio)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { RadioButton, RadioButtonGroup } from '@eightshift/ui-components';
 

--- a/website/ui-components/es-ui-components/repeater-helpers.js
+++ b/website/ui-components/es-ui-components/repeater-helpers.js
@@ -1,5 +1,5 @@
 import { Repeater, RepeaterItem, InputField, Toggle } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import { emptyCircle, magicAlt } from '@eightshift/ui-components/icons';
 
 export const RepeaterDemo = ({ data, setData, ...rest }) => {
 	return (
@@ -18,10 +18,10 @@ export const RepeaterDemo = ({ data, setData, ...rest }) => {
 				return (
 					<RepeaterItem
 						label={title ?? `New item ${itemIndex + 1}`}
-						icon={icons.magicAlt}
+						icon={magicAlt}
 					>
 						<Toggle
-							icon={icons.emptyCircle}
+							icon={emptyCircle}
 							label='Toggle me'
 							checked={toggledOption}
 							onChange={(value) => updateData({ toggledOption: value })}

--- a/website/ui-components/es-ui-components/repeater.mdx
+++ b/website/ui-components/es-ui-components/repeater.mdx
@@ -1,5 +1,9 @@
 # Repeater
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/repeater)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { RepeaterDemo } from './repeater-helpers';
 

--- a/website/ui-components/es-ui-components/responsive-preview.mdx
+++ b/website/ui-components/es-ui-components/responsive-preview.mdx
@@ -2,7 +2,7 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { ResponsivePreview } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+
 import { globalManifest, responsiveOptions, breakpointNames } from './responsive-helpers';
 
 <ComponentShowcase

--- a/website/ui-components/es-ui-components/responsive-preview.mdx
+++ b/website/ui-components/es-ui-components/responsive-preview.mdx
@@ -1,5 +1,9 @@
 # Responsive preview
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/responsive-preview)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { ResponsivePreview } from '@eightshift/ui-components';
 

--- a/website/ui-components/es-ui-components/responsive.mdx
+++ b/website/ui-components/es-ui-components/responsive.mdx
@@ -1,5 +1,9 @@
 # Responsive
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/responsive)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { Responsive, ResponsiveLegacy, Button, OptionSelect, MiniResponsive } from '@eightshift/ui-components';
 import { fontFamily } from '@eightshift/ui-components/icons';

--- a/website/ui-components/es-ui-components/responsive.mdx
+++ b/website/ui-components/es-ui-components/responsive.mdx
@@ -2,7 +2,8 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { Responsive, ResponsiveLegacy, Button, OptionSelect, MiniResponsive } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import { fontFamily } from '@eightshift/ui-components/icons';
+
 import { globalManifest, responsiveOptions, breakpointNames, responsiveLegacyAttr } from './responsive-helpers';
 
 Easily manage values that can be set per-breakpoint.
@@ -22,7 +23,7 @@ If using Frontend libs (that has **one attribute per breakpoint**), use the [Res
 >
 	{(data, setData) => (
 		<Responsive
-			icon={icons.fontFamily}
+			icon={fontFamily}
 			label='Font family'
 			value={data}
 			onChange={setData}
@@ -43,7 +44,7 @@ If using Frontend libs (that has **one attribute per breakpoint**), use the [Res
 
 ```jsx
 <Responsive
-	icon={icons.fontFamily}
+	icon={fontFamily}
 	label='Font family'
 	value={value}
 	onChange={(value) => setValue(value)}
@@ -91,7 +92,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 >
 	{(data, setData) => (
 		<Responsive
-			icon={icons.fontFamily}
+			icon={fontFamily}
 			label='Font family'
 			value={data}
 			onChange={setData}
@@ -113,7 +114,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 
 ```jsx
 <Responsive
-	icon={icons.fontFamily}
+	icon={fontFamily}
 	label='Font family'
 	value={value}
 	onChange={(value) => setValue(value)}
@@ -159,7 +160,7 @@ Only applies to the control for the default breakpoint.
 >
 	{(data, setData) => (
 		<Responsive
-			icon={icons.fontFamily}
+			icon={fontFamily}
 			label='Font family'
 			value={data}
 			onChange={setData}
@@ -182,7 +183,7 @@ Only applies to the control for the default breakpoint.
 
 ```jsx
 <Responsive
-	icon={icons.fontFamily}
+	icon={fontFamily}
 	label='Font family'
 	value={value}
 	onChange={(value) => setValue(value)}
@@ -230,7 +231,7 @@ Only applies to the control for the default breakpoint.
 >
 	{(data, setData) => (
 		<Responsive
-			icon={icons.fontFamily}
+			icon={fontFamily}
 			label='Font family'
 			value={data}
 			onChange={setData}
@@ -253,7 +254,7 @@ Only applies to the control for the default breakpoint.
 
 ```jsx
 <Responsive
-	icon={icons.fontFamily}
+	icon={fontFamily}
 	label='Font family'
 	value={value}
 	onChange={(value) => setValue(value)}
@@ -297,7 +298,7 @@ Only applies to the control for the default breakpoint.
 >
 	{(data, setData) => (
 		<Responsive
-			icon={icons.fontFamily}
+			icon={fontFamily}
 			label='Font family'
 			value={data}
 			onChange={setData}
@@ -319,7 +320,7 @@ Only applies to the control for the default breakpoint.
 
 ```jsx
 <Responsive
-	icon={icons.fontFamily}
+	icon={fontFamily}
 	label='Font family'
 	value={value}
 	onChange={(value) => setValue(value)}
@@ -365,7 +366,7 @@ Using single button pickers is recommended, though. (`isInlineCollapsedView` is 
 >
 	{(data, setData) => (
 		<MiniResponsive
-			icon={icons.fontFamily}
+			icon={fontFamily}
 			label='Font family'
 			value={data}
 			onChange={setData}
@@ -387,7 +388,7 @@ Using single button pickers is recommended, though. (`isInlineCollapsedView` is 
 
 ```jsx
 <MiniResponsive
-	icon={icons.fontFamily}
+	icon={fontFamily}
 	label='Font family'
 	value={data}
 	onChange={setData}
@@ -432,7 +433,7 @@ Main differences:
 >
 	{(data, setData) => (
 		<ResponsiveLegacy
-			icon={icons.fontFamily}
+			icon={fontFamily}
 			label='Font family'
 			attribute={responsiveLegacyAttr}
 			value={data}
@@ -460,7 +461,7 @@ Main differences:
 
 ```jsx
 <ResponsiveLegacy
-	icon={icons.fontFamily}
+	icon={fontFamily}
 	label='Font family'
 	attribute={manifest.responsiveAttributes.myAttr}
 	value={attributes}

--- a/website/ui-components/es-ui-components/rich-label.mdx
+++ b/website/ui-components/es-ui-components/rich-label.mdx
@@ -1,5 +1,9 @@
 # Rich label
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/rich-label)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { RichLabel } from '@eightshift/ui-components';
 import { emptyCircle, solidCircleFilled } from '@eightshift/ui-components/icons';

--- a/website/ui-components/es-ui-components/rich-label.mdx
+++ b/website/ui-components/es-ui-components/rich-label.mdx
@@ -2,7 +2,8 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { RichLabel } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import { emptyCircle, solidCircleFilled } from '@eightshift/ui-components/icons';
+
 import { globalManifest, responsiveOptions, breakpointNames } from './responsive-helpers';
 
 Upgrade your basic labels with an optional icon and subtitle.
@@ -11,7 +12,7 @@ Upgrade your basic labels with an optional icon and subtitle.
 	<RichLabel
 		label='Label ipsum dolor sit amet'
 		subtitle='Subtitle ipsum dolor sit amet'
-		icon={icons.emptyCircle}
+		icon={emptyCircle}
 	/>
 </ComponentShowcase>
 
@@ -19,7 +20,7 @@ Upgrade your basic labels with an optional icon and subtitle.
 <RichLabel
 	label='Label ipsum dolor sit amet'
 	subtitle='Subtitle ipsum dolor sit amet'
-	icon={icons.emptyCircle}
+	icon={emptyCircle}
 />
 ```
 
@@ -33,7 +34,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 	<RichLabel
 		label='Label ipsum dolor sit amet'
 		subtitle='Subtitle ipsum dolor sit amet'
-		icon={icons.emptyCircle}
+		icon={emptyCircle}
 		fullWidth
 	/>
 </ComponentShowcase>
@@ -42,7 +43,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 <RichLabel
 	label='Label ipsum dolor sit amet'
 	subtitle='Subtitle ipsum dolor sit amet'
-	icon={icons.emptyCircle}
+	icon={emptyCircle}
 	// highlight-next-line
 	fullWidth
 />
@@ -57,7 +58,7 @@ use the `noColor` prop to use opacity to highlight hierarchy instead of multiple
 	<RichLabel
 		label='Label ipsum dolor sit amet'
 		subtitle='Subtitle ipsum dolor sit amet'
-		icon={icons.solidCircleFilled}
+		icon={solidCircleFilled}
 	/>
 </ComponentShowcase>
 
@@ -66,7 +67,7 @@ use the `noColor` prop to use opacity to highlight hierarchy instead of multiple
 <RichLabel
 	label='Label ipsum dolor sit amet'
 	subtitle='Subtitle ipsum dolor sit amet'
-	icon={icons.solidCircleFilled}
+	icon={solidCircleFilled}
 />
 ```
 
@@ -74,7 +75,7 @@ use the `noColor` prop to use opacity to highlight hierarchy instead of multiple
 	<RichLabel
 		label='Label ipsum dolor sit amet'
 		subtitle='Subtitle ipsum dolor sit amet'
-		icon={icons.solidCircleFilled}
+		icon={solidCircleFilled}
 
     	noColor
     />
@@ -86,7 +87,7 @@ use the `noColor` prop to use opacity to highlight hierarchy instead of multiple
 <RichLabel
 	label='Label ipsum dolor sit amet'
 	subtitle='Subtitle ipsum dolor sit amet'
-	icon={icons.solidCircleFilled}
+	icon={solidCircleFilled}
 	// highlight-next-line
 	noColor
 />

--- a/website/ui-components/es-ui-components/select-customization.mdx
+++ b/website/ui-components/es-ui-components/select-customization.mdx
@@ -1,5 +1,9 @@
 # Customization
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/select)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { Select, AsyncSelect, MultiSelect, AsyncMultiSelect, HStack } from '@eightshift/ui-components';
 import * as icons from '@eightshift/ui-components/icons';

--- a/website/ui-components/es-ui-components/select-customization.mdx
+++ b/website/ui-components/es-ui-components/select-customization.mdx
@@ -2,7 +2,7 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { Select, AsyncSelect, MultiSelect, AsyncMultiSelect, HStack } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import * as icons from '@eightshift/ui-components/icons';
 import { demoOptions, demoGetData } from './select-helpers';
 
 Select components allow many customizations to adapt to various use cases.

--- a/website/ui-components/es-ui-components/select.mdx
+++ b/website/ui-components/es-ui-components/select.mdx
@@ -1,5 +1,9 @@
 # Single select
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/select)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { Select } from '@eightshift/ui-components';
 

--- a/website/ui-components/es-ui-components/select.mdx
+++ b/website/ui-components/es-ui-components/select.mdx
@@ -2,7 +2,7 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { Select } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+
 import { demoOptions } from './select-helpers';
 
 <ComponentShowcase>

--- a/website/ui-components/es-ui-components/slider.mdx
+++ b/website/ui-components/es-ui-components/slider.mdx
@@ -2,7 +2,7 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { Slider } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import { magicAltFillTransparent } from '@eightshift/ui-components/icons';
 
 <ComponentShowcase defaultValue={0}>
 	{(data, setData) => {
@@ -227,7 +227,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 				value={data}
 				onChange={setData}
 				aria-label='Slider'
-				before={icons.magicAltFillTransparent}
+				before={magicAltFillTransparent}
 			/>
 		);
 	}}
@@ -238,7 +238,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 	value={value}
 	onChange={(value) => setData(value)}
 	// highlight-next-line
-	before={icons.magicAltFillTransparent}
+	before={magicAltFillTransparent}
 />
 ```
 
@@ -251,7 +251,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 				value={data}
 				onChange={setData}
 				aria-label='Slider'
-				after={icons.magicAltFillTransparent}
+				after={magicAltFillTransparent}
 			/>
 		);
 	}}
@@ -262,7 +262,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 	value={value}
 	onChange={(value) => setData(value)}
 	// highlight-next-line
-	after={icons.magicAltFillTransparent}
+	after={magicAltFillTransparent}
 />
 ```
 

--- a/website/ui-components/es-ui-components/slider.mdx
+++ b/website/ui-components/es-ui-components/slider.mdx
@@ -1,5 +1,9 @@
 # Slider
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/slider)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { Slider } from '@eightshift/ui-components';
 import { magicAltFillTransparent } from '@eightshift/ui-components/icons';

--- a/website/ui-components/es-ui-components/solid-color-picker.mdx
+++ b/website/ui-components/es-ui-components/solid-color-picker.mdx
@@ -1,5 +1,9 @@
 # Solid color picker
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/color-pickers)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { SolidColorPicker } from '@eightshift/ui-components';
 
@@ -79,9 +83,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 
 ### Hide advanced options
 
-<ComponentShowcase
-	defaultValue='#0D3636'
->
+<ComponentShowcase defaultValue='#0D3636'>
 	{(data, setData) => {
 		return (
 			<SolidColorPicker

--- a/website/ui-components/es-ui-components/solid-color-picker.mdx
+++ b/website/ui-components/es-ui-components/solid-color-picker.mdx
@@ -2,7 +2,6 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { SolidColorPicker } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
 
 <ComponentShowcase defaultValue='#0D3636'>
 	{(data, setData) => {

--- a/website/ui-components/es-ui-components/spacer.mdx
+++ b/website/ui-components/es-ui-components/spacer.mdx
@@ -1,5 +1,9 @@
 # Spacer
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/spacer)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { Spacer } from '@eightshift/ui-components';
 import { emptyRect } from '@eightshift/ui-components/icons';

--- a/website/ui-components/es-ui-components/spacer.mdx
+++ b/website/ui-components/es-ui-components/spacer.mdx
@@ -2,7 +2,7 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { Spacer } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import { emptyRect } from '@eightshift/ui-components/icons';
 
 :::note
 The violet color <div className='es:bg-violet-50 es:transition es:size-5.5 es:rounded es:inline-block' /> in the examples is used to highlight the space added by the component.
@@ -86,14 +86,14 @@ For the complete list of props, use your IDE's autocomplete functionality.
 <ComponentShowcase className='esd-hide-bg-on-hover'>
 	<Spacer
 		className='es:bg-violet-50 es:transition'
-		icon={icons.emptyRect}
+		icon={emptyRect}
 	/>
 </ComponentShowcase>
 
 ```jsx
 <Spacer
 	// highlight-next-line
-	icon={icons.emptyRect}
+	icon={emptyRect}
 />
 ```
 
@@ -101,14 +101,14 @@ For the complete list of props, use your IDE's autocomplete functionality.
 	<Spacer
 		border
 		className='es:bg-violet-50 es:transition'
-		icon={icons.emptyRect}
+		icon={emptyRect}
 	/>
 </ComponentShowcase>
 
 ```jsx
 <Spacer
 	// highlight-next-line
-	icon={icons.emptyRect}
+	icon={emptyRect}
 	border
 />
 ```
@@ -190,13 +190,13 @@ For the complete list of props, use your IDE's autocomplete functionality.
 		className='es:bg-violet-50 es:transition'
 		text='This is a label'
 		subtitle='Subtitle'
-		icon={icons.emptyRect}
+		icon={emptyRect}
 	/>
 </ComponentShowcase>
 
 ```jsx
 <Spacer
-	icon={icons.emptyRect}
+	icon={emptyRect}
 	text='This is a label'
 	subtitle='Subtitle'
 	border

--- a/website/ui-components/es-ui-components/spinner.mdx
+++ b/website/ui-components/es-ui-components/spinner.mdx
@@ -1,5 +1,9 @@
 # Spinner
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/icons)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { Spinner } from '@eightshift/ui-components/icons';
 

--- a/website/ui-components/es-ui-components/spinner.mdx
+++ b/website/ui-components/es-ui-components/spinner.mdx
@@ -1,0 +1,34 @@
+# Spinner
+
+import { ComponentShowcase } from '../components/component-showcase';
+import { Spinner } from '@eightshift/ui-components/icons';
+
+A small loading indicator used inside buttons, async controls, and placeholders. Exported from `@eightshift/ui-components/icons`.
+
+<ComponentShowcase>
+	<Spinner />
+</ComponentShowcase>
+
+```jsx
+import { Spinner } from '@eightshift/ui-components/icons';
+
+<Spinner />;
+```
+
+## Sizing and color
+
+`Spinner` accepts a `className` and renders as a `<div>`. The default size is `size-8` and the default color is the accent color. Override both by passing Tailwind utility classes:
+
+<ComponentShowcase>
+	<Spinner className='es:size-4 es:text-surface-600' />
+</ComponentShowcase>
+
+```jsx
+<Spinner className='es:size-4 es:text-surface-600' />
+```
+
+## Highlighted props
+
+| Prop        | Description                                                                                 |
+| ----------- | ------------------------------------------------------------------------------------------- |
+| `className` | Appended to the spinner's class list. Use for size, color, and additional motion utilities. |

--- a/website/ui-components/es-ui-components/stacks.mdx
+++ b/website/ui-components/es-ui-components/stacks.mdx
@@ -1,5 +1,9 @@
 # Horizontal and vertical stacks
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/layout)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { HStack, VStack, Button, Checkbox } from '@eightshift/ui-components';
 import {

--- a/website/ui-components/es-ui-components/stacks.mdx
+++ b/website/ui-components/es-ui-components/stacks.mdx
@@ -2,73 +2,88 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { HStack, VStack, Button, Checkbox } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import {
+	bot,
+	componentGeneric,
+	cookieAlt,
+	design,
+	edit,
+	experiment,
+	gridAlt,
+	group,
+	magicAlt,
+	num1Circle,
+	num2Circle,
+	num3Circle,
+	num4Circle,
+	wrench,
+} from '@eightshift/ui-components/icons';
 
 Simple one-dimensional layouts made easy.
 
 <ComponentShowcase>
 	<HStack>
-		<Button icon={icons.experiment} />
-		<Button icon={icons.magicAlt} />
-		<Button icon={icons.wrench} />
-		<Button icon={icons.bot} />
+		<Button icon={experiment} />
+		<Button icon={magicAlt} />
+		<Button icon={wrench} />
+		<Button icon={bot} />
 	</HStack>
 </ComponentShowcase>
 
 ```jsx
 <HStack>
-	<Button icon={icons.experiment} />
-	<Button icon={icons.magicAlt} />
-	<Button icon={icons.wrench} />
-	<Button icon={icons.bot} />
+	<Button icon={experiment} />
+	<Button icon={magicAlt} />
+	<Button icon={wrench} />
+	<Button icon={bot} />
 </HStack>
 ```
 
 <ComponentShowcase>
 	<VStack>
-		<Button icon={icons.experiment} />
-		<Button icon={icons.magicAlt} />
-		<Button icon={icons.wrench} />
-		<Button icon={icons.bot} />
+		<Button icon={experiment} />
+		<Button icon={magicAlt} />
+		<Button icon={wrench} />
+		<Button icon={bot} />
 	</VStack>
 </ComponentShowcase>
 
 ```jsx
 <VStack>
-	<Button icon={icons.experiment} />
-	<Button icon={icons.magicAlt} />
-	<Button icon={icons.wrench} />
-	<Button icon={icons.bot} />
+	<Button icon={experiment} />
+	<Button icon={magicAlt} />
+	<Button icon={wrench} />
+	<Button icon={bot} />
 </VStack>
 ```
 
 <ComponentShowcase>
 	<HStack>
-		<Button icon={icons.experiment} />
-		<Button icon={icons.magicAlt} />
+		<Button icon={experiment} />
+		<Button icon={magicAlt} />
 		<VStack>
-			<Button icon={icons.num1Circle} />
-			<Button icon={icons.num2Circle} />
-			<Button icon={icons.num3Circle} />
-			<Button icon={icons.num4Circle} />
+			<Button icon={num1Circle} />
+			<Button icon={num2Circle} />
+			<Button icon={num3Circle} />
+			<Button icon={num4Circle} />
 		</VStack>
-		<Button icon={icons.wrench} />
-		<Button icon={icons.bot} />
+		<Button icon={wrench} />
+		<Button icon={bot} />
 	</HStack>
 </ComponentShowcase>
 
 ```jsx
 <HStack>
-	<Button icon={icons.experiment} />
-	<Button icon={icons.magicAlt} />
+	<Button icon={experiment} />
+	<Button icon={magicAlt} />
 	<VStack>
-		<Button icon={icons.num1Circle} />
-		<Button icon={icons.num2Circle} />
-		<Button icon={icons.num3Circle} />
-		<Button icon={icons.num4Circle} />
+		<Button icon={num1Circle} />
+		<Button icon={num2Circle} />
+		<Button icon={num3Circle} />
+		<Button icon={num4Circle} />
 	</VStack>
-	<Button icon={icons.wrench} />
-	<Button icon={icons.bot} />
+	<Button icon={wrench} />
+	<Button icon={bot} />
 </HStack>
 ```
 
@@ -90,17 +105,17 @@ For the complete list of props, use your IDE's autocomplete functionality.
 >
 	{(data) => (
 		<HStack noWrap={!data}>
-		<Button icon={icons.experiment} />
-		<Button icon={icons.magicAlt} />
-		<Button icon={icons.wrench} />
-		<Button icon={icons.bot} />
-		<Button icon={icons.edit} />
-		<Button icon={icons.componentGeneric} />
-		<Button icon={icons.group} />
-		<Button icon={icons.design} />
-		<Button icon={icons.cookieAlt} />
-		<Button icon={icons.gridAlt} />
-	</HStack>
+			<Button icon={experiment} />
+			<Button icon={magicAlt} />
+			<Button icon={wrench} />
+			<Button icon={bot} />
+			<Button icon={edit} />
+			<Button icon={componentGeneric} />
+			<Button icon={group} />
+			<Button icon={design} />
+			<Button icon={cookieAlt} />
+			<Button icon={gridAlt} />
+		</HStack>
 	)}
 </ComponentShowcase>
 

--- a/website/ui-components/es-ui-components/tabs.mdx
+++ b/website/ui-components/es-ui-components/tabs.mdx
@@ -2,7 +2,6 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { Tabs, Tab, TabList, TabPanel, OptionSelect, Checkbox } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
 
 <ComponentShowcase>
 	<Tabs>

--- a/website/ui-components/es-ui-components/tabs.mdx
+++ b/website/ui-components/es-ui-components/tabs.mdx
@@ -1,5 +1,9 @@
 # Tabs
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/tabs)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { Tabs, Tab, TabList, TabPanel, OptionSelect, Checkbox } from '@eightshift/ui-components';
 

--- a/website/ui-components/es-ui-components/toggle-button.mdx
+++ b/website/ui-components/es-ui-components/toggle-button.mdx
@@ -2,7 +2,6 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { ToggleButton } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
 
 <ComponentShowcase defaultValue={false}>
 	{(data, setData) => {

--- a/website/ui-components/es-ui-components/toggle-button.mdx
+++ b/website/ui-components/es-ui-components/toggle-button.mdx
@@ -1,5 +1,9 @@
 # Toggle button
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/toggle-button)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { ToggleButton } from '@eightshift/ui-components';
 

--- a/website/ui-components/es-ui-components/toggle-switch.mdx
+++ b/website/ui-components/es-ui-components/toggle-switch.mdx
@@ -2,7 +2,7 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { Toggle, Switch, Button } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import { emptyRect } from '@eightshift/ui-components/icons';
 
 <ComponentShowcase defaultValue={false}>
 	{(data, setData) => {
@@ -54,13 +54,14 @@ Other props are the same, with the exception of label and related props.
 For the complete list of props, use your IDE's autocomplete functionality.
 
 ### Icon, subtitle
+
 Augment the label
 
 <ComponentShowcase defaultValue={false}>
 	{(data, setData) => {
 		return (
 			<Toggle
-				icon={icons.emptyRect}
+				icon={emptyRect}
 				subtitle='Subtitle'
 				checked={data}
 				onChange={setData}
@@ -73,7 +74,7 @@ Augment the label
 ```jsx
 <Toggle
 	// highlight-start
-	icon={icons.emptyRect}
+	icon={emptyRect}
 	subtitle='Subtitle'
 	// highlight-end
 	label='Demo'
@@ -83,6 +84,7 @@ Augment the label
 ```
 
 ### Disabled
+
 Prevent interactions with the toggle.
 
 <ComponentShowcase defaultValue={false}>
@@ -109,6 +111,7 @@ Prevent interactions with the toggle.
 ```
 
 ### Indeterminate state
+
 Whether the toggle should be rendered in an indeterminate state.
 
 <ComponentShowcase

--- a/website/ui-components/es-ui-components/toggle-switch.mdx
+++ b/website/ui-components/es-ui-components/toggle-switch.mdx
@@ -1,5 +1,9 @@
 # Toggle / Switch
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/toggle)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { Toggle, Switch, Button } from '@eightshift/ui-components';
 import { emptyRect } from '@eightshift/ui-components/icons';

--- a/website/ui-components/es-ui-components/tooltip.mdx
+++ b/website/ui-components/es-ui-components/tooltip.mdx
@@ -2,7 +2,6 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { Button, Tooltip, DecorativeTooltip, HStack } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
 
 Tooltips don't usually need to be used directly, as they are used internally by other components.
 By default, they only work with components that properly handle pointer events.

--- a/website/ui-components/es-ui-components/tooltip.mdx
+++ b/website/ui-components/es-ui-components/tooltip.mdx
@@ -1,5 +1,9 @@
 # Tooltip
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/tooltip)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { Button, Tooltip, DecorativeTooltip, HStack } from '@eightshift/ui-components';
 

--- a/website/ui-components/es-ui-components/triggered-popover.mdx
+++ b/website/ui-components/es-ui-components/triggered-popover.mdx
@@ -1,8 +1,17 @@
-# Triggered popover
+# Popover
 
 import { ComponentShowcase } from '../components/component-showcase';
-import { TriggeredPopover, Button } from '@eightshift/ui-components';
+import { Popover, TriggeredPopover, Button } from '@eightshift/ui-components';
 import { pointerHand, trash } from '@eightshift/ui-components/icons';
+
+Two popover components are exported:
+
+- `TriggeredPopover` — the easy path. Renders a trigger (a `Button` by default) and manages the open/close state internally.
+- `Popover` — the lower-level primitive. You bring your own trigger via a `triggerRef` and either let it manage its own state with `openByDefault` or drive it from the outside with `isOpen` / `onOpenChange`.
+
+Both share placement, offset and styling props.
+
+## Triggered popover
 
 <ComponentShowcase>
 	<TriggeredPopover>
@@ -18,11 +27,11 @@ import { pointerHand, trash } from '@eightshift/ui-components/icons';
 </TriggeredPopover>
 ```
 
-## Highlighted props
+### Highlighted props
 
 For the complete list of props, use your IDE's autocomplete functionality.
 
-### Trigger button customization
+#### Trigger button customization
 
 <ComponentShowcase>
 	<TriggeredPopover
@@ -46,7 +55,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 </TriggeredPopover>
 ```
 
-#### More advanced customizations
+##### More advanced customizations
 
 `triggerButtonProps` accepts all props a [`Button`](/components/es-ui-components/button) accepts.
 
@@ -78,7 +87,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 </TriggeredPopover>
 ```
 
-## Offset from trigger
+### Offset from trigger
 
 `offset` controls the space between the trigger and the popover on the main opening axis.
 
@@ -117,3 +126,70 @@ For the complete list of props, use your IDE's autocomplete functionality.
 	<div>This is demo content</div>
 </TriggeredPopover>
 ```
+
+## Standalone Popover
+
+Use the standalone `Popover` when you need full control of the trigger — for example, when the trigger isn't a `Button`, when the open state is driven by external logic, or when several elements should be able to open the same popover.
+
+`Popover` requires a `triggerRef` that points to the element the popover should anchor to.
+
+### Uncontrolled (managed internally)
+
+Pass `openByDefault` and let `Popover` manage its own state. It will open and close based on user interaction with the referenced trigger.
+
+```jsx
+import { useRef } from 'react';
+import { Popover, Button } from '@eightshift/ui-components';
+
+const triggerRef = useRef(null);
+
+<Button forwardedRef={triggerRef}>Open popover</Button>
+
+<Popover
+	triggerRef={triggerRef}
+	openByDefault
+>
+	<div>This is demo content</div>
+</Popover>
+```
+
+### Controlled
+
+Drive the open state from outside using `isOpen` and `onOpenChange`.
+
+```jsx
+import { useRef, useState } from 'react';
+import { Popover, Button } from '@eightshift/ui-components';
+
+const triggerRef = useRef(null);
+const [isOpen, setIsOpen] = useState(false);
+
+<Button
+	forwardedRef={triggerRef}
+	onPress={() => setIsOpen(true)}
+>
+	Open popover
+</Button>
+
+<Popover
+	triggerRef={triggerRef}
+	isOpen={isOpen}
+	onOpenChange={setIsOpen}
+>
+	<div>This is demo content</div>
+</Popover>
+```
+
+### Highlighted props
+
+| Prop                           | Description                                                                                          |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `triggerRef`                   | `RefObject` to the element the popover should anchor to. Required.                                   |
+| `isOpen` / `onOpenChange`      | Controlled open state.                                                                               |
+| `openByDefault`                | Uncontrolled initial state.                                                                          |
+| `placement`                    | `top`, `bottom`, `left`, `right` (with `start`/`end` variants).                                      |
+| `offset` / `crossOffset`       | Distance from the trigger on the main and cross axes.                                                |
+| `containerPadding`             | Minimum padding kept between the popover and the viewport edge.                                      |
+| `shouldFlip`                   | Whether the popover may flip to the opposite side when there isn't enough space. Defaults to `true`. |
+| `shouldCloseOnInteractOutside` | Function receiving the interacted element; return `false` to keep the popover open.                  |
+| `aria-label`                   | Accessible label for the dialog. Pass `false` to opt out when the popover already contains a label.  |

--- a/website/ui-components/es-ui-components/triggered-popover.mdx
+++ b/website/ui-components/es-ui-components/triggered-popover.mdx
@@ -2,7 +2,7 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { TriggeredPopover, Button } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import { pointerHand, trash } from '@eightshift/ui-components/icons';
 
 <ComponentShowcase>
 	<TriggeredPopover>
@@ -27,7 +27,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 <ComponentShowcase>
 	<TriggeredPopover
 		triggerButtonLabel='Click me'
-		triggerButtonIcon={icons.pointerHand}
+		triggerButtonIcon={pointerHand}
 	>
 		<div className='es:w-full es:rounded-xl es:bg-gray-100 es:text-sm es:p-4 es:min-h-40'>
 			<span>This is demo content</span>
@@ -39,7 +39,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 <TriggeredPopover
 	// highlight-start
 	triggerButtonLabel='Click me'
-	triggerButtonIcon={icons.pointerHand}
+	triggerButtonIcon={pointerHand}
 	// highlight-end
 >
 	<div>This is demo content</div>
@@ -52,7 +52,7 @@ For the complete list of props, use your IDE's autocomplete functionality.
 
 <ComponentShowcase>
 	<TriggeredPopover
-		triggerButtonIcon={icons.trash}
+		triggerButtonIcon={trash}
 		triggerButtonProps={{ type: 'danger' }}
 		className='es:p-4'
 	>
@@ -60,17 +60,17 @@ For the complete list of props, use your IDE's autocomplete functionality.
 		<br />
 		<span>There's no going back (whoa-oh)</span>
 
-		<div className='es:flex es:gap-2 es:mt-3'>
-			<Button className='es:ml-auto' type='ghost'>Yup!</Button>
-			<Button>Nope</Button>
-		</div>
-	</TriggeredPopover>
+    	<div className='es:flex es:gap-2 es:mt-3'>
+    		<Button className='es:ml-auto' type='ghost'>Yup!</Button>
+    		<Button>Nope</Button>
+    	</div>
+    </TriggeredPopover>
 
 </ComponentShowcase>
 
 ```jsx
 <TriggeredPopover
-	triggerButtonIcon={icons.trash}
+	triggerButtonIcon={trash}
 	// highlight-next-line
 	triggerButtonProps={{ type: 'danger' }}
 >

--- a/website/ui-components/es-ui-components/triggered-popover.mdx
+++ b/website/ui-components/es-ui-components/triggered-popover.mdx
@@ -1,5 +1,9 @@
 # Popover
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/components/popover)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { Popover, TriggeredPopover, Button } from '@eightshift/ui-components';
 import { pointerHand, trash } from '@eightshift/ui-components/icons';

--- a/website/ui-components/es-ui-components/ui-icons.mdx
+++ b/website/ui-components/es-ui-components/ui-icons.mdx
@@ -1,5 +1,9 @@
 # UI icons
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/icons/ui-icons)
+:::
+
 import { ComponentShowcase } from '../components/component-showcase';
 import { Button, InputField } from '@eightshift/ui-components';
 import * as icons from '@eightshift/ui-components/icons';

--- a/website/ui-components/es-ui-components/ui-icons.mdx
+++ b/website/ui-components/es-ui-components/ui-icons.mdx
@@ -2,7 +2,7 @@
 
 import { ComponentShowcase } from '../components/component-showcase';
 import { Button, InputField } from '@eightshift/ui-components';
-import { icons } from '@eightshift/ui-components/icons';
+import * as icons from '@eightshift/ui-components/icons';
 
 Regular React components, use within components, option pages, sidebar, ...
 
@@ -20,28 +20,32 @@ Regular React components, use within components, option pages, sidebar, ...
 	)}
 >
 	{(data) => {
-		const filteredIcons = Object.keys(icons).filter((k) =>
-			data?.length > 0 ? k.toLowerCase().includes(data?.toLowerCase()) : true
-		);
-
-		if (filteredIcons.length < 1)  {
-			return (
-				<span>Nothing found</span>
+		const filteredIcons = Object.keys(icons)
+			.filter((k) => /^[a-z]/.test(k))
+			.filter((k) => icons[k]?.$$typeof !== undefined)
+			.filter((k) =>
+				data?.length > 0 ? k.toLowerCase().includes(data?.toLowerCase()) : true
 			);
-		}
 
-		return filteredIcons.map((icon, index) => (
-			<Button
-				key={index}
-				className='esd-icon-showcase-button'
-				icon={icons[icon]}
-				tooltip={<span className='es:font-mono'>{icon}</span>}
-				aria-label={icon}
-				onPress={() => {
-					navigator.clipboard.writeText(icon);
-				}}
-				type='simple'
-			/>
-		));
-	}}
+    	if (filteredIcons.length < 1)  {
+    		return (
+    			<span>Nothing found</span>
+    		);
+    	}
+
+    	return filteredIcons.map((icon, index) => (
+    		<Button
+    			key={index}
+    			className='esd-icon-showcase-button'
+    			icon={icons[icon]}
+    			tooltip={<span className='es:font-mono'>{icon}</span>}
+    			aria-label={icon}
+    			onPress={() => {
+    				navigator.clipboard.writeText(icon);
+    			}}
+    			type='simple'
+    		/>
+    	));
+    }}
+
 </ComponentShowcase>

--- a/website/ui-components/es-ui-components/utilities.mdx
+++ b/website/ui-components/es-ui-components/utilities.mdx
@@ -1,0 +1,125 @@
+# Utilities
+
+A collection of helper functions that ship with `@eightshift/ui-components`. They are exported from a dedicated subpath, so importing them does not pull in any React code:
+
+```jsx
+import { camelCase, debounce, isEqual } from '@eightshift/ui-components/utilities';
+```
+
+The exception is `getColumnConfigOutputText`, which is exported from the main package entry alongside the components.
+
+## String helpers
+
+Case conversion and basic string utilities, backed by the [`just-*`](https://github.com/angus-c/just) family of dependency-free helpers.
+
+| Function                     | Description                                                                                               |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `camelCase(input)`           | Converts to `camelCase`. `null`/`undefined` becomes `''`.                                                 |
+| `pascalCase(input)`          | Converts to `PascalCase`.                                                                                 |
+| `snakeCase(input)`           | Converts to `snake_case`.                                                                                 |
+| `kebabCase(input)`           | Converts to `kebab-case`.                                                                                 |
+| `upperFirst(input)`          | Uppercases the first character. Handles non-string inputs (numbers, booleans).                            |
+| `lowerFirst(input)`          | Lowercases the first character.                                                                           |
+| `truncate(input, max)`       | Truncates the end of a string to fit `max` characters and appends `...` (or a custom separator).          |
+| `truncateEnd(input, max)`    | Alias of `truncate`.                                                                                      |
+| `truncateMiddle(input, max)` | Truncates the middle of a string (great for URLs), inserting the separator between the head and the tail. |
+| `unescapeHTML(input)`        | Decodes HTML entities to their character equivalents (uses `DOMParser`, so DOM-only).                     |
+
+```jsx
+camelCase('New super Test-title'); // 'newSuperTestTitle'
+truncateMiddle('https://eightshift.com/contact/', 22); // 'https://ei.../contact/'
+```
+
+## Object & value helpers
+
+Dependency-free type guards and structural comparisons.
+
+| Function               | Description                                                                                                     |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `isEmpty(value)`       | `true` for `{}`, `[]`, `''`, `null`, `undefined`.                                                               |
+| `isObject(value)`      | `true` for any object-like value, including arrays and functions.                                               |
+| `isPlainObject(value)` | `true` only for objects produced by the `Object` constructor or with a `null` prototype.                        |
+| `isString(value)`      | `true` for primitive strings and `String` objects.                                                              |
+| `isEqual(a, b)`        | Deep-equal check for primitives, arrays, and plain objects. Not a full lodash replacement — keep inputs simple. |
+| `has(obj, 'a.b')`      | `true` if the dotted path exists on the object.                                                                 |
+
+```jsx
+isEqual({ a: 1 }, { a: 1 }); // true
+has({ a: { b: 2 } }, 'a.b'); // true
+```
+
+## Array helpers
+
+| Function                                                | Description                                                                                                                |
+| ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `arrayMoveMultiple(array, fromIndices, to, direction?)` | Returns a new array with the items at `fromIndices` moved to index `to`. `direction` is `'before'` (default) or `'after'`. |
+| `fixIds(items, onChange, idKey?)`                       | Detects missing or duplicate IDs and calls `onChange` with a renumbered array. Defaults to the `id` key.                   |
+
+```jsx
+const next = arrayMoveMultiple(['a', 'b', 'c', 'd'], [0, 2], 3, 'after');
+// ['b', 'd', 'a', 'c']
+```
+
+## Timing helpers
+
+Thin wrappers around `just-debounce-it` and `just-throttle`, typed for convenience.
+
+| Function                                  | Description                                                                               |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `debounce(fn, wait = 250)`                | Returns a debounced version of `fn`.                                                      |
+| `throttle(fn, wait = 250, after = false)` | Returns a throttled version of `fn`. Pass `after = true` to trigger on the trailing edge. |
+
+```jsx
+const onSearch = debounce((value) => fetchResults(value), 300);
+```
+
+## General helpers
+
+| Function                                | Description                                                                               |
+| --------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `getFileExtension(url)`                 | Extracts the file extension from a URL string. Returns `null` if no extension is present. |
+| `isColorDark(r, g, b, threshold = 0.5)` | Returns `true` if the given RGB color is below the lightness threshold (`0`–`1`).         |
+
+```jsx
+getFileExtension('https://example.com/image.png'); // 'png'
+isColorDark(20, 20, 20); // true
+```
+
+## Hashing & IDs
+
+Small, non-cryptographic hashes suitable for things like memoization keys or React `key` props. Do **not** use them for anything security-sensitive.
+
+| Function                 | Description                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------ |
+| `simpleHash(str)`        | 32-bit base-36 hash, always 7 characters. Fast, low collision resistance.                              |
+| `cyrb64Hash(str, seed?)` | 64-bit base-36 hash, always 14 characters. Better collision resistance, still not cryptographic.       |
+| `randomId(length)`       | Random alphanumeric string of the requested length. Uses `Math.random` — not cryptographically secure. |
+
+## Class name helpers
+
+`clsx` is re-exported from `clsx/lite` (smaller, supports strings and conditional strings only). `clsxFull` is the full `clsx` import, which also accepts objects and arrays.
+
+```jsx
+import { clsx, clsxFull } from '@eightshift/ui-components/utilities';
+
+clsx('a', condition && 'b'); // lite variant
+clsxFull('a', { b: condition }, ['c', 'd']); // full variant
+```
+
+## Column configuration text
+
+`getColumnConfigOutputText` returns a translated, human-readable description of a column range (used by `ColumnConfigSlider`). It is exported from the **main** package entry, not from `/utilities`.
+
+```jsx
+import { getColumnConfigOutputText } from '@eightshift/ui-components';
+
+getColumnConfigOutputText(12, 1, 12); // 'Full-width'
+getColumnConfigOutputText(12, 3, 4); // '4 cols from 3'
+```
+
+| Argument            | Description                                                                               |
+| ------------------- | ----------------------------------------------------------------------------------------- |
+| `columns`           | Total number of columns in the layout.                                                    |
+| `offset`            | 1-based starting column.                                                                  |
+| `width`             | Number of columns covered.                                                                |
+| `showOuterAsGutter` | When `true`, treats column `1` and column `columns` as gutter columns and labels them so. |

--- a/website/ui-components/es-ui-components/utilities.mdx
+++ b/website/ui-components/es-ui-components/utilities.mdx
@@ -1,5 +1,9 @@
 # Utilities
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/utilities)
+:::
+
 A collection of helper functions that ship with `@eightshift/ui-components`. They are exported from a dedicated subpath, so importing them does not pull in any React code:
 
 ```jsx

--- a/website/ui-components/es-ui-components/wp-overrides.mdx
+++ b/website/ui-components/es-ui-components/wp-overrides.mdx
@@ -1,0 +1,51 @@
+# WP overrides
+
+Optional stylesheets that smooth out the default WordPress block editor so it matches the look and feel of Eightshift UI components. Each file is opt-in — import only the ones you want.
+
+```scss
+@import '@eightshift/ui-components/dist/assets/wp-overrides/<name>.css';
+```
+
+The package also exposes them via shorthand exports, useful with bundlers that resolve `exports`:
+
+```scss
+@import '@eightshift/ui-components/wp-overrides/<name>';
+```
+
+:::caution
+If you are using Frontend libs v12 or older, skip these overrides — Frontend libs ships its own WordPress styling and the two sets will fight each other. See [Migrations](/components/es-ui-components/migrations) if you're moving from `wp-ui-enhancements.css`.
+:::
+
+## Available overrides
+
+| File                        | What it does                                                                                                                                     |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `allow-full-width-blocks`   | Lets blocks inside the post content layout expand to the full container width.                                                                   |
+| `fix-label-text-case`       | Normalizes the casing, size, and weight of labels in `BaseControl`, `InputControl`, and `CustomSelectControl`.                                   |
+| `increase-sidebar-width`    | Widens the editor sidebar so longer labels and controls have room to breathe (handles WP 6.6 quirks).                                            |
+| `make-block-messages-nicer` | Restyles the block crash and "block missing" warnings to match the Eightshift visual language.                                                   |
+| `replace-fonts`             | Replaces the default editor font with the Eightshift font stack across the header, sidebar, controls, popovers, tooltips, etc.                   |
+| `restyle-tooltips`          | Replaces the default Gutenberg `.components-tooltip` styling with a darker, blurred variant, and a light variant for tooltips with rich content. |
+| `round-corners`             | Adds consistent rounded corners to buttons, snackbars, modals, the publish panel, and other commonly-encountered editor controls.                |
+| `unify-button-sizes`        | Forces a consistent minimum size on top-toolbar buttons so the toolbar reads as a single row.                                                    |
+
+## Recommended block editor setup
+
+```scss title="application-blocks-editor.css"
+@import '@eightshift/ui-components/dist/assets/wp-overrides/replace-fonts.css';
+@import '@eightshift/ui-components/dist/assets/wp-overrides/fix-label-text-case.css';
+@import '@eightshift/ui-components/dist/assets/wp-overrides/increase-sidebar-width.css';
+@import '@eightshift/ui-components/dist/assets/wp-overrides/make-block-messages-nicer.css';
+@import '@eightshift/ui-components/dist/assets/wp-overrides/restyle-tooltips.css';
+@import '@eightshift/ui-components/dist/assets/wp-overrides/round-corners.css';
+@import '@eightshift/ui-components/dist/assets/wp-overrides/unify-button-sizes.css';
+@import '@eightshift/ui-components/dist/assets/wp-overrides/allow-full-width-blocks.css';
+
+@import '@eightshift/ui-components/dist/assets/style.css'; // or style-editor.css for non-Tailwind projects
+```
+
+For the WP admin area, the standalone `style-admin.css` is usually enough:
+
+```scss title="application-admin.css"
+@import '@eightshift/ui-components/dist/assets/style-admin.css';
+```

--- a/website/ui-components/es-ui-components/wp-overrides.mdx
+++ b/website/ui-components/es-ui-components/wp-overrides.mdx
@@ -1,5 +1,9 @@
 # WP overrides
 
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-ui-components/tree/main/lib/wp-overrides)
+:::
+
 Optional stylesheets that smooth out the default WordPress block editor so it matches the look and feel of Eightshift UI components. Each file is opt-in — import only the ones you want.
 
 ```scss


### PR DESCRIPTION
# Description

Updates `@eightshift/ui-components` from `^6.3.0` to `^7.3.0` and refreshes all UI component documentation pages to match the v7 API. Also bumps Docusaurus and a few transitive deps.

## Package updates (`website/package.json`)

- `@docusaurus/core` `^3.9.2` → `^3.10.1`
- `@docusaurus/preset-classic` `^3.9.2` → `^3.10.1`
- `@eightshift/ui-components` `^6.3.0` → `^7.3.0`
- `caniuse-lite` `^1.0.30001781` → `^1.0.30001792`
- `baseline-browser-mapping` `^2.10.10` → `^2.10.29`
- Added `use-sync-external-store` `^1.6.0`

## New documentation pages

- `es-ui-components/jsx-svg.mdx`
- `es-ui-components/spinner.mdx`
- `es-ui-components/utilities.mdx`
- `es-ui-components/wp-overrides.mdx`

Sidebar (`sidebars-components.js`) updated to include the new pages under **Icons** (`jsx-svg`, `spinner`) and at the top level (`utilities`, `wp-overrides`).

## Updated documentation pages (v7 API alignment)

44 existing MDX pages refreshed across `es-ui-components/` — including `base-control`, `button`, `option-select`, `stacks`, `triggered-popover`, `ui-icons`, `expandable`, `responsive`, `placeholders`, plus all form controls (selects, checkbox, radio, slider, toggle-switch, number-picker), pickers (color, gradient, solid-color), and layout primitives (menu, modal, tabs, tooltip, container-panel, options-panel).

Helper files updated: `draggable-list-helpers.js`, `link-input-helpers.js`, `repeater-helpers.js`, `component-showcase.js`.

# Screenshots / Videos
<img width="736" height="546" alt="Screenshot 2026-05-20 at 10 39 42" src="https://github.com/user-attachments/assets/26af5d47-29b1-4c4b-99c6-30992ba7db63" />


