### PR TITLE
Add Frontend libs Tailwind components and helpers docs

### DIFF
--- a/website/sidebars-components.js
+++ b/website/sidebars-components.js
@@ -3,7 +3,7 @@ module.exports = {
 		'welcome',
 		{
 			type: 'category',
-			label: 'Eightshift UI components',
+			label: 'Eightshift UI-Components',
 			items: [
 				'es-ui-components/getting-started',
 				{
@@ -118,8 +118,28 @@ module.exports = {
 		},
 		{
 			type: 'category',
-			label: 'Frontend libs components',
-			items: ['fe-libs-components/introduction'],
+			label: 'Frontend libs Tailwind',
+			items: [
+				'fe-libs-tailwind/getting-started',
+				{
+					type: 'category',
+					label: 'Components',
+					items: [
+						'fe-libs-tailwind/block-inserter',
+						'fe-libs-tailwind/link-section-editor',
+						'fe-libs-tailwind/file-picker',
+						'fe-libs-tailwind/media-picker',
+						'fe-libs-tailwind/picker-placeholder',
+						'fe-libs-tailwind/server-side-render',
+						'fe-libs-tailwind/theme-options',
+					],
+				},
+				{
+					type: 'category',
+					label: 'Helpers',
+					items: ['fe-libs-tailwind/breakpoints', 'fe-libs-tailwind/cookies', 'fe-libs-tailwind/dynamic-import'],
+				},
+			],
 		},
 	],
 };

--- a/website/ui-components/fe-libs-components/introduction.mdx
+++ b/website/ui-components/fe-libs-components/introduction.mdx
@@ -1,5 +1,0 @@
-# Introduction
-
-## **🚧 Work in progress, coming soon!**
-
-This will cover UI components included with Frontend libs 13+.

--- a/website/ui-components/fe-libs-tailwind/block-inserter.mdx
+++ b/website/ui-components/fe-libs-tailwind/block-inserter.mdx
@@ -1,0 +1,66 @@
+# BlockInserter
+
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-frontend-libs-tailwind/blob/main/scripts/components/block-inserter.js)
+:::
+
+A drop-in replacement for the default Gutenberg block inserter button, whose styling can vary between WordPress versions. Renders as an Eightshift UI [Button](../es-ui-components/button) with the standard `add` icon.
+
+By default, the inserter only shows when the parent block is selected — pass `alwaysVisible` to keep it visible at all times.
+
+```jsx
+import { BlockInserter } from '@eightshift/frontend-libs-tailwind/scripts';
+
+<InnerBlocks renderAppender={() => <BlockInserter clientId={clientId} />} />;
+```
+
+## With a label
+
+Pass `label={true}` to render the default localized label — _"Add a block"_, or _"Add &lt;BlockName&gt;"_ when the parent only allows a single block type.
+
+```jsx
+<BlockInserter
+	clientId={clientId}
+	label
+/>
+```
+
+You can also pass a custom string or JSX element as the label.
+
+```jsx
+<BlockInserter
+	clientId={clientId}
+	label={__('Add a card', 'my-theme')}
+/>
+```
+
+## Highlighted props
+
+| Prop                 | Type                               | Description                                                                                              |
+| -------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `clientId`           | `string`                           | **Required.** Client ID of the block the inserter belongs to.                                            |
+| `label`              | `boolean \| string \| JSX.Element` | Label to render next to the icon. `true` uses the default localized label.                               |
+| `small`              | `boolean`                          | Renders the trigger button at `small` size. Useful inside nested InnerBlocks.                            |
+| `prioritizePatterns` | `boolean`                          | Show patterns before blocks in the inserter modal.                                                       |
+| `alwaysVisible`      | `boolean`                          | If `true`, the inserter renders regardless of whether the parent block is selected. Defaults to `false`. |
+| `hidden`             | `boolean`                          | If `true`, nothing is rendered.                                                                          |
+| `className`          | `string`                           | Extra classes appended to the trigger button.                                                            |
+
+## Always visible
+
+```jsx
+<BlockInserter
+	clientId={clientId}
+	alwaysVisible
+	label
+/>
+```
+
+## Compact inserter for nested InnerBlocks
+
+```jsx
+<BlockInserter
+	clientId={clientId}
+	small
+/>
+```

--- a/website/ui-components/fe-libs-tailwind/breakpoints.mdx
+++ b/website/ui-components/fe-libs-tailwind/breakpoints.mdx
@@ -1,0 +1,88 @@
+# Breakpoints
+
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-frontend-libs-tailwind/blob/main/scripts/helpers/breakpoints.js)
+:::
+
+Helpers for reading the project's breakpoint configuration from the Eightshift block-editor store. These are thin wrappers around `select(STORE_NAME).getSettings()` — useful when feeding the [Responsive](../es-ui-components/responsive) component or building responsive UI in the editor.
+
+## getGlobalManifest
+
+Returns the full global manifest stored in the Eightshift store.
+
+```js
+import { getGlobalManifest } from '@eightshift/frontend-libs-tailwind/scripts';
+
+const manifest = getGlobalManifest();
+// → { globalVariables: { breakpoints: { ... }, ... }, ... }
+```
+
+## getBreakpointNames
+
+Returns the breakpoint names **sorted ascending by their pixel value**.
+
+```js
+import { getBreakpointNames } from '@eightshift/frontend-libs-tailwind/scripts';
+
+getBreakpointNames();
+// → ['mobile', 'tablet', 'desktop', 'large']
+```
+
+## getBreakpointData
+
+Returns the raw `breakpoints` map from the global manifest. Pass `true` to multiply each value by `16` (useful if your manifest stores rem-style numbers but you need pixel values).
+
+```js
+import { getBreakpointData } from '@eightshift/frontend-libs-tailwind/scripts';
+
+getBreakpointData();
+// → { mobile: 480, tablet: 960, desktop: 1440, large: 1920 }
+
+getBreakpointData(true);
+// → { mobile: 7680, tablet: 15360, ... }   // ← multiplied by 16
+```
+
+| Argument      | Type      | Description                                                  |
+| ------------- | --------- | ------------------------------------------------------------ |
+| `convertToPx` | `boolean` | Multiply each breakpoint value by `16`. Defaults to `false`. |
+
+## getBreakpointUiData
+
+Returns the UI-only metadata for breakpoints (icons, labels, …) if your manifest defines one under `globalVariables.breakpointData`.
+
+```js
+import { getBreakpointUiData } from '@eightshift/frontend-libs-tailwind/scripts';
+
+const uiData = getBreakpointUiData();
+// → { mobile: { label: 'Mobile', icon: <…> }, ... }
+```
+
+## getResponsiveData
+
+The one-stop helper for the [Responsive](../es-ui-components/responsive) component. Returns `breakpoints`, `breakpointData`, and — if defined — `breakpointUiData` in one object, ready to spread into `<Responsive>`.
+
+```jsx
+import { Responsive } from '@eightshift/ui-components';
+import { getResponsiveData } from '@eightshift/frontend-libs-tailwind/scripts';
+
+<Responsive
+	value={value}
+	onChange={setValue}
+	options={fontFamilyOptions}
+	{...getResponsiveData()}
+/>;
+```
+
+| Argument      | Type      | Description                                            |
+| ------------- | --------- | ------------------------------------------------------ |
+| `convertToPx` | `boolean` | Forwarded to `getBreakpointData`. Defaults to `false`. |
+
+Return value:
+
+```js
+{
+	breakpoints: ['mobile', 'tablet', 'desktop', 'large'],
+	breakpointData: { mobile: 480, tablet: 960, desktop: 1440, large: 1920 },
+	breakpointUiData: { ... },   // only if defined in the manifest
+}
+```

--- a/website/ui-components/fe-libs-tailwind/cookies.mdx
+++ b/website/ui-components/fe-libs-tailwind/cookies.mdx
@@ -1,0 +1,62 @@
+# cookies
+
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-frontend-libs-tailwind/blob/main/scripts/helpers/cookies.js)
+:::
+
+A small object with helpers for reading and writing `document.cookie`, plus a few presets for common expirations.
+
+```js
+import { cookies } from '@eightshift/frontend-libs-tailwind/scripts';
+
+cookies.setCookie('gdpr', '2', cookies.setOneDay(), '/', '.example.com', true, 'Strict');
+
+const consent = cookies.getCookie('gdpr');
+```
+
+## setCookie
+
+```js
+cookies.setCookie(key, value, time, path, domain, (secure = true), (sameSite = 'Lax'));
+```
+
+| Argument   | Type                          | Description                                                                                        |
+| ---------- | ----------------------------- | -------------------------------------------------------------------------------------------------- |
+| `key`      | `string`                      | Cookie name.                                                                                       |
+| `value`    | `string`                      | Cookie value.                                                                                      |
+| `time`     | `number`                      | Lifetime in milliseconds, added to `Date.now()`. Use the `setOneDay`/`setOneYear`/… presets below. |
+| `path`     | `string`                      | URL path that must match for the cookie to be sent. Omit/falsy to skip.                            |
+| `domain`   | `string`                      | Domain the cookie is scoped to. Omit/falsy to skip.                                                |
+| `secure`   | `boolean`                     | Only send the cookie over HTTPS. Defaults to `true`.                                               |
+| `sameSite` | `'Strict' \| 'Lax' \| 'None'` | `SameSite` attribute. Defaults to `'Lax'`.                                                         |
+
+Returns `true` on success, `false` on failure (and logs the error).
+
+## getCookie
+
+```js
+cookies.getCookie('gdpr');
+// → '2' (or null if not set)
+```
+
+| Argument | Type     | Description  |
+| -------- | -------- | ------------ |
+| `key`    | `string` | Cookie name. |
+
+Returns the cookie value as a string, or `null` if the cookie isn't set.
+
+## Expiration presets
+
+Each returns a number of milliseconds you can pass as the `time` argument to `setCookie`.
+
+| Preset                    | Value (ms)       | ≈          |
+| ------------------------- | ---------------- | ---------- |
+| `cookies.setHalfAnHour()` | `1_800_000`      | 30 minutes |
+| `cookies.setHalfDay()`    | `43_200_000`     | 12 hours   |
+| `cookies.setOneDay()`     | `86_400_000`     | 24 hours   |
+| `cookies.setOneMonth()`   | `2_628_000_000`  | ~30.4 days |
+| `cookies.setOneYear()`    | `31_540_000_000` | ~365 days  |
+
+```js
+cookies.setCookie('preview', 'on', cookies.setHalfAnHour(), '/');
+```

--- a/website/ui-components/fe-libs-tailwind/dynamic-import.mdx
+++ b/website/ui-components/fe-libs-tailwind/dynamic-import.mdx
@@ -1,0 +1,43 @@
+# dynamicImport
+
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-frontend-libs-tailwind/blob/main/scripts/helpers/dynamic-import.js)
+:::
+
+A one-liner helper that iterates a webpack `require.context` and imports every file it returns. Typically used to side-effect-import all blocks, components, or assets matching a glob — without listing them by hand.
+
+```js
+import { dynamicImport } from '@eightshift/frontend-libs-tailwind/scripts';
+
+dynamicImport(require.context('./../../custom', true, /assets\/index.js$/));
+```
+
+## Signature
+
+```js
+dynamicImport(paths);
+```
+
+| Argument | Type                                | Description                                                       |
+| -------- | ----------------------------------- | ----------------------------------------------------------------- |
+| `paths`  | `__WebpackModuleApi.RequireContext` | The `require.context` whose keys should be iterated and imported. |
+
+Returns `undefined`. The function exists for the side effect of importing — every matched file is executed when called.
+
+:::note
+`require.context` is a webpack-specific API. If you're on Vite or another bundler, use that bundler's equivalent (e.g., `import.meta.glob`) instead — `dynamicImport` won't help there.
+:::
+
+## Common patterns
+
+**Import every block's editor entry:**
+
+```js
+dynamicImport(require.context('./../../custom', true, /assets\/index.js$/));
+```
+
+**Import every component's style entry:**
+
+```js
+dynamicImport(require.context('./../../components', true, /style\.scss$/));
+```

--- a/website/ui-components/fe-libs-tailwind/file-picker.mdx
+++ b/website/ui-components/fe-libs-tailwind/file-picker.mdx
@@ -1,0 +1,99 @@
+# File picker
+
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-frontend-libs-tailwind/blob/main/scripts/components/file-picker.js)
+:::
+
+Two components for working with the WordPress Media library:
+
+- `ManageFileButton` — a single button that opens the media modal in `browse`, `upload`, or `replace` mode.
+- `FileSelector` — a complete file-picker UI (preview + replace + remove) built around `FilePickerShell` from Eightshift UI components.
+
+Both support different `kind`s (`file`, `image`, `video`, `subtitle`, `geoJson`, `lottie`, `rive`, `custom`) which control labels and icons in the modal and on the buttons.
+
+## ManageFileButton
+
+A customizable button that opens the media modal. Use it directly when you only need a single action (e.g., a standalone "Upload" or "Replace" button) and don't want the surrounding `FilePickerShell`.
+
+```jsx
+import { ManageFileButton } from '@eightshift/frontend-libs-tailwind/scripts';
+
+<ManageFileButton
+	onChange={(media) => setAttributes({ fileId: media.id, fileUrl: media.url })}
+	allowedTypes={['application/pdf']}
+/>;
+```
+
+### Highlighted props
+
+| Prop           | Type                                                                                        | Description                                                                                               |
+| -------------- | ------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `onChange`     | `(media) => void`                                                                           | **Required.** Called with the selected media item (`{ id, url, ... }`).                                   |
+| `type`         | `'browse' \| 'upload' \| 'replace'`                                                         | Mode for the underlying media modal. Defaults to `browse`.                                                |
+| `kind`         | `'file' \| 'image' \| 'video' \| 'subtitle' \| 'geoJson' \| 'lottie' \| 'rive' \| 'custom'` | Controls labels and icons. Defaults to `file`.                                                            |
+| `currentId`    | `string`                                                                                    | ID of the currently selected item. Used with `type='replace'` to mark the current selection in the modal. |
+| `allowedTypes` | `string[]`                                                                                  | **Required.** Allowed MIME types.                                                                         |
+| `compact`      | `boolean`                                                                                   | Renders the button as icon-only.                                                                          |
+| `labels`       | `{ buttonLabel?, modalTitle?, buttonIcon?, removeIcon? }`                                   | Only applies when `kind='custom'`. Overrides labels and icons.                                            |
+| `buttonProps`  | `object`                                                                                    | Forwarded to the trigger `Button`.                                                                        |
+| `hidden`       | `boolean`                                                                                   | If `true`, nothing is rendered.                                                                           |
+
+### Replace mode
+
+```jsx
+<ManageFileButton
+	type='replace'
+	kind='image'
+	currentId={imageId}
+	allowedTypes={['image']}
+	onChange={onChange}
+/>
+```
+
+### Custom labels and icons
+
+```jsx
+<ManageFileButton
+	kind='custom'
+	labels={{
+		buttonLabel: { browse: __('Pick a thing', 'my-theme') },
+		modalTitle: { browse: __('Choose your thing', 'my-theme') },
+		buttonIcon: { browse: myIcon },
+	}}
+	allowedTypes={['application/pdf']}
+	onChange={onChange}
+/>
+```
+
+## FileSelector
+
+A higher-level picker that wraps `FilePickerShell`: it shows the empty state (browse + upload) when no file is selected, and a replace/remove pair when one is. Pass any [FilePickerShell](https://github.com/infinum/eightshift-ui-components) prop through and it will be forwarded.
+
+```jsx
+import { FileSelector } from '@eightshift/frontend-libs-tailwind/scripts';
+
+<FileSelector
+	onChange={onChange}
+	fileId={fileId}
+	fileName={fileName}
+	allowedTypes={['video']}
+	kind='video'
+/>;
+```
+
+### Highlighted props
+
+| Prop           | Type                                                                                        | Description                                                                                                       |
+| -------------- | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `onChange`     | `(media) => void`                                                                           | **Required.** Called with `{ id, url, ... }` on select, or `{ id: undefined, url: undefined }` on remove.         |
+| `fileId`       | `string`                                                                                    | **Required.** ID of the current file.                                                                             |
+| `fileName`     | `string`                                                                                    | **Required.** Name/URL of the current file, used both for the preview and as the URL passed to `FilePickerShell`. |
+| `allowedTypes` | `string[]`                                                                                  | **Required.** Allowed MIME types.                                                                                 |
+| `kind`         | `'file' \| 'image' \| 'video' \| 'subtitle' \| 'geoJson' \| 'lottie' \| 'rive' \| 'custom'` | Controls labels and icons. Defaults to `file`.                                                                    |
+| `noDelete`     | `boolean`                                                                                   | Hide the "Remove" button.                                                                                         |
+| `noUpload`     | `boolean`                                                                                   | Hide the "Upload" button in the empty state.                                                                      |
+| `labels`       | `object`                                                                                    | Same shape as `ManageFileButton.labels`. Applies when `kind='custom'`.                                            |
+
+:::note
+`FileSelector` forwards any unrecognized prop to the underlying `FilePickerShell`, so you can also pass `icon`, `noUrlContent` overrides, custom class names, etc.
+:::

--- a/website/ui-components/fe-libs-tailwind/getting-started.mdx
+++ b/website/ui-components/fe-libs-tailwind/getting-started.mdx
@@ -1,0 +1,9 @@
+# Getting started
+
+Frontend libs Tailwind ships a small set of helpers and editor-side React components built on top of [Eightshift UI components](../es-ui-components/getting-started) and the WordPress block editor APIs.
+
+They cover the common building blocks you reach for when authoring blocks, custom theme options pages, or working with breakpoints in a Tailwind-based project.
+
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-frontend-libs-tailwind/tree/main/scripts)
+:::

--- a/website/ui-components/fe-libs-tailwind/link-section-editor.mdx
+++ b/website/ui-components/fe-libs-tailwind/link-section-editor.mdx
@@ -1,0 +1,57 @@
+# LinkSectionEditor
+
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-frontend-libs-tailwind/blob/main/scripts/components/link-section-editor.js)
+:::
+
+An inline editor for hierarchical sections of links — each section has a header and a list of link items (`text`, `url`, `newTab`). Designed for things like footer link columns or megamenu sections.
+
+Keyboard behavior is built-in:
+
+- `Enter` on an item adds a new link below.
+- `Cmd` / `Ctrl` + `Enter` on a header or item creates a new section after the current one.
+- `Backspace` on an empty item removes it; on an empty header removes the whole section.
+
+```jsx
+import { LinkSectionEditor } from '@eightshift/frontend-libs-tailwind/scripts';
+
+<LinkSectionEditor
+	links={links}
+	onChange={(newLinks) => setAttributes({ links: newLinks })}
+	classNames={{
+		sectionContainer: 'section-container',
+		sectionTitle: 'section-title',
+		link: 'link',
+	}}
+/>;
+```
+
+## Data shape
+
+```js
+const links = [
+	{
+		header: 'Section 1',
+		items: [
+			{ text: 'Link 1', url: 'https://example.com', newTab: false },
+			{ text: 'Link 2', url: 'https://example.com', newTab: false },
+		],
+	},
+	{
+		header: 'Section 2',
+		items: [{ text: 'Link 1', url: 'https://example.com', newTab: false }],
+	},
+];
+```
+
+:::note
+The editor manages `text` and `header` values via `RichText`. The `url` and `newTab` fields are part of the data model but are not edited by this component — wire them up separately (e.g., through a link popover) if you need them.
+:::
+
+## Highlighted props
+
+| Prop         | Type                                                                                      | Description                                                                                    |
+| ------------ | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `links`      | `Array<{ header: string, items: Array<{ text: string, url: string, newTab: boolean }> }>` | **Required.** Current link sections.                                                           |
+| `onChange`   | `(newLinks) => void`                                                                      | **Required.** Called with the updated array whenever a section, header, or item changes.       |
+| `classNames` | `{ sectionContainer?: string, sectionTitle?: string, link?: string }`                     | CSS classes forwarded to the section wrapper, the header `RichText`, and each link `RichText`. |

--- a/website/ui-components/fe-libs-tailwind/media-picker.mdx
+++ b/website/ui-components/fe-libs-tailwind/media-picker.mdx
@@ -1,0 +1,57 @@
+# MediaPicker
+
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-frontend-libs-tailwind/blob/main/scripts/components/media-picker.js)
+:::
+
+A picker for **image** attachments — a thin wrapper around `FilePickerShell` that always uses `kind='image'` and adapts the button style based on the rendered image preview (the buttons switch between `glass` and `glassDark` to stay legible over the artwork).
+
+```jsx
+import { MediaPicker } from '@eightshift/frontend-libs-tailwind/scripts';
+
+<MediaPicker
+	onChange={({ id, url }) => setAttributes({ imageId: id, imageUrl: url })}
+	imageId={imageId}
+	imageUrl={imageUrl}
+/>;
+```
+
+## Highlighted props
+
+| Prop           | Type              | Description                                                                                               |
+| -------------- | ----------------- | --------------------------------------------------------------------------------------------------------- |
+| `onChange`     | `(media) => void` | **Required.** Called with `{ id, url, ... }` on select, or `{ id: undefined, url: undefined }` on remove. |
+| `imageId`      | `string`          | ID of the currently selected image. Used when replacing to mark the current selection.                    |
+| `imageUrl`     | `string`          | URL of the currently selected image. Drives the preview.                                                  |
+| `allowedTypes` | `string[]`        | Allowed MIME types. Defaults to `['image']`.                                                              |
+| `noDelete`     | `boolean`         | Hide the "Remove" button.                                                                                 |
+| `noUpload`     | `boolean`         | Hide the "Upload" button in the empty state.                                                              |
+| `hidden`       | `boolean`         | If `true`, nothing is rendered.                                                                           |
+| `className`    | `string`          | Extra classes for the picker wrapper.                                                                     |
+
+## Restricting to a single type
+
+```jsx
+<MediaPicker
+	onChange={onChange}
+	imageId={imageId}
+	imageUrl={imageUrl}
+	allowedTypes={['image/svg+xml']}
+/>
+```
+
+## Read-only picker (no upload, no delete)
+
+```jsx
+<MediaPicker
+	onChange={onChange}
+	imageId={imageId}
+	imageUrl={imageUrl}
+	noUpload
+	noDelete
+/>
+```
+
+:::note
+For non-image media, reach for [FileSelector](./file-picker#fileselector) with the matching `kind` instead.
+:::

--- a/website/ui-components/fe-libs-tailwind/picker-placeholder.mdx
+++ b/website/ui-components/fe-libs-tailwind/picker-placeholder.mdx
@@ -1,0 +1,74 @@
+# PickerPlaceholder
+
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-frontend-libs-tailwind/blob/main/scripts/components/picker-placeholder.js)
+:::
+
+An empty-state placeholder for blocks that ship with one or more **layout presets**. Each preset can pre-fill block attributes and insert inner blocks. Optionally pairs with a [BlockInserter](./block-inserter) for the _"or pick a block manually"_ escape hatch.
+
+```jsx
+import { PickerPlaceholder } from '@eightshift/frontend-libs-tailwind/scripts';
+
+<PickerPlaceholder
+	clientId={clientId}
+	title={__('Hero', 'my-theme')}
+	blockIcon='hero'
+	presets={[
+		{
+			name: __('Two columns', 'my-theme'),
+			icon: 'columns',
+			attributes: { layout: 'two-columns' },
+			blocks: [
+				{ name: 'my-theme/heading', attributes: { content: 'Title' } },
+				{ name: 'my-theme/paragraph', attributes: { content: 'Body' } },
+			],
+		},
+	]}
+	onChange={(attrs) => setAttributes(attrs)}
+	inserter
+/>;
+```
+
+## Driving it from the manifest
+
+If you pass `manifest`, the component reads `title`, `icon.src`, and `layoutPresets` from it — so you don't need to pass `title`, `blockIcon`, or `presets` separately.
+
+```jsx
+import manifest from './manifest.json';
+
+<PickerPlaceholder
+	clientId={clientId}
+	manifest={manifest}
+	onChange={(attrs) => setAttributes(attrs)}
+/>;
+```
+
+## Highlighted props
+
+| Prop             | Type                                          | Description                                                                                                                                         |
+| ---------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `clientId`       | `string`                                      | **Required.** Client ID of the block. Used to insert the preset's inner blocks.                                                                     |
+| `onChange`       | `(attributes) => void`                        | **Required.** Called with the preset's `attributes` when the user picks one.                                                                        |
+| `presets`        | `Array<{ name, icon, blocks?, attributes? }>` | Presets shown as buttons. `blocks` is an array of `{ name, attributes }` inserted into the block.                                                   |
+| `title`          | `string \| JSX.Element`                       | Heading shown at the top. Falls back to `manifest.title`.                                                                                           |
+| `blockIcon`      | `string \| JSX.Element`                       | Icon shown next to the title. Strings are looked up first in `blockIcons`, then resolved as a generic icon name. Falls back to `manifest.icon.src`. |
+| `manifest`       | `object`                                      | Block/component manifest, used as a fallback source for `title`, `blockIcon`, and `presets` (`layoutPresets`).                                      |
+| `inserter`       | `boolean \| JSX.Element`                      | If `true`, renders a default [BlockInserter](./block-inserter); pass a custom element to render that instead.                                       |
+| `presetsHeading` | `string`                                      | Header above the preset buttons. Defaults to _"Select a preset"_.                                                                                   |
+| `hidden`         | `boolean`                                     | If `true`, nothing is rendered.                                                                                                                     |
+
+## Preset shape
+
+```js
+{
+	name: 'Two columns',       // Button label
+	icon: 'columns',           // Icon name from @eightshift/ui-components/icons
+	attributes: {              // Optional: merged into the parent block
+		layout: 'two-columns',
+	},
+	blocks: [                  // Optional: inserted as inner blocks
+		{ name: 'my-theme/heading', attributes: { content: 'Title' } },
+		{ name: 'my-theme/paragraph', attributes: { content: 'Body' } },
+	],
+}
+```

--- a/website/ui-components/fe-libs-tailwind/server-side-render.mdx
+++ b/website/ui-components/fe-libs-tailwind/server-side-render.mdx
@@ -1,0 +1,37 @@
+# ServerSideRender
+
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-frontend-libs-tailwind/blob/main/scripts/components/server-side-render.js)
+:::
+
+A thin wrapper around Gutenberg's [`@wordpress/server-side-render`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-server-side-render/) that adds a consistent dotted-border preview container and disables pointer events so the render is non-interactive in the editor.
+
+```jsx
+import { ServerSideRender } from '@eightshift/frontend-libs-tailwind/scripts';
+
+<ServerSideRender
+	block='my-theme/latest-posts'
+	attributes={attributes}
+/>;
+```
+
+## Highlighted props
+
+| Prop         | Type     | Description                                                              |
+| ------------ | -------- | ------------------------------------------------------------------------ |
+| `block`      | `string` | **Required.** Fully qualified block name (e.g. `my-theme/latest-posts`). |
+| `attributes` | `object` | Block attributes passed to the PHP render callback.                      |
+| `className`  | `string` | Extra classes appended to the preview wrapper.                           |
+
+Any other prop is forwarded to the underlying `@wordpress/server-side-render` — see the [WordPress reference](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-server-side-render/) for the full list (`urlQueryArgs`, `httpMethod`, `EmptyResponsePlaceholder`, `ErrorResponsePlaceholder`, `LoadingResponsePlaceholder`, …).
+
+## Custom loading / empty / error states
+
+```jsx
+<ServerSideRender
+	block='my-theme/latest-posts'
+	attributes={attributes}
+	LoadingResponsePlaceholder={() => <Spinner />}
+	EmptyResponsePlaceholder={() => <p>{__('No posts yet.', 'my-theme')}</p>}
+/>
+```

--- a/website/ui-components/fe-libs-tailwind/theme-options.mdx
+++ b/website/ui-components/fe-libs-tailwind/theme-options.mdx
@@ -1,0 +1,87 @@
+# Theme options
+
+:::tip
+[View source on GitHub →](https://github.com/infinum/eightshift-frontend-libs-tailwind/blob/main/scripts/components/settings)
+:::
+
+A small kit for building **custom theme options pages** that read and write from `wp/v2/settings`. Three pieces work together:
+
+- `ThemeOptionsPage` — the page shell with a header, save button, and a `Toaster` for success/error feedback.
+- `useThemeOptions` — hook that loads, holds, and saves the settings via `apiFetch`.
+- `EsThemeOptionsContext` — React context that exposes the hook's return value to any child component.
+
+Based on the WordPress developer blog post [_How to use WordPress React components for plugin pages_](https://developer.wordpress.org/news/2024/03/26/how-to-use-wordpress-react-components-for-plugin-pages/).
+
+## ThemeOptionsPage
+
+The page shell. Renders the header (title + save button), exposes the settings via context, and mounts a [Sonner](https://sonner.emilkowal.ski/) `Toaster` for the save feedback toasts.
+
+```jsx
+import { ThemeOptionsPage, EsThemeOptionsContext } from '@eightshift/frontend-libs-tailwind/scripts';
+import { useContext } from '@wordpress/element';
+import { InputField } from '@eightshift/ui-components';
+
+const ContactFields = () => {
+	const { settings, updateSettings } = useContext(EsThemeOptionsContext);
+
+	return (
+		<>
+			<InputField
+				label='Contact email'
+				value={settings?.contactEmail ?? ''}
+				onChange={(v) => updateSettings({ contactEmail: v })}
+			/>
+		</>
+	);
+};
+
+const App = () => (
+	<ThemeOptionsPage
+		title={__('Site options', 'my-theme')}
+		settingName='my-theme-options'
+	>
+		<ContactFields />
+	</ThemeOptionsPage>
+);
+```
+
+### Highlighted props
+
+| Prop          | Type          | Description                                                                                                                          |
+| ------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `title`       | `string`      | Page heading. Defaults to _"Theme options"_.                                                                                         |
+| `settingName` | `string`      | WordPress option key to read/write. Defaults to `eightshift-theme-options`. The value must be a JSON-encoded string in the database. |
+| `children`    | `JSX.Element` | The page body — typically a tree of `OptionsPanel` / `ContainerPanel` components that read from `EsThemeOptionsContext`.             |
+
+:::note
+The option referenced by `settingName` must be registered on the PHP side with `show_in_rest: true` so it's exposed via `/wp/v2/settings`. The value is stored as a JSON-encoded string — `useThemeOptions` handles the encoding and decoding for you.
+:::
+
+## useThemeOptions
+
+The hook that powers `ThemeOptionsPage`. Use it directly if you want to build a custom shell.
+
+```js
+import { useThemeOptions } from '@eightshift/frontend-libs-tailwind/scripts';
+
+const { settings, setSettings, updateSettings, saveSettings, isLoading } = useThemeOptions('my-theme-options');
+```
+
+| Returned         | Type                  | Description                                                                            |
+| ---------------- | --------------------- | -------------------------------------------------------------------------------------- |
+| `settings`       | `object \| undefined` | The decoded option value. `undefined` while loading.                                   |
+| `setSettings`    | `(next) => void`      | Replaces the whole settings object.                                                    |
+| `updateSettings` | `(partial) => void`   | Shallow-merges `partial` into the current settings. The usual way to update one field. |
+| `saveSettings`   | `() => Promise<void>` | Persists the current settings via `apiFetch`. Shows a success/error toast.             |
+| `isLoading`      | `boolean`             | `true` while a save is in flight.                                                      |
+
+## EsThemeOptionsContext
+
+A standard React context that exposes the value returned by `useThemeOptions`. Use it from any child component of `ThemeOptionsPage` to read or update settings without prop-drilling.
+
+```jsx
+import { useContext } from '@wordpress/element';
+import { EsThemeOptionsContext } from '@eightshift/frontend-libs-tailwind/scripts';
+
+const { settings, updateSettings } = useContext(EsThemeOptionsContext);
+```


### PR DESCRIPTION
# Description

Documents the components and helpers shipped by `@eightshift/frontend-libs-tailwind` under a new sidebar section **Frontend libs Tailwind**, matching the visual structure of the existing `es-ui-components` pages (intro + `:::tip` source link + code examples + prop tables).

### Added

**Getting started**
- `fe-libs-tailwind/getting-started.mdx` — overview of what the package ships and links to each new page.

**Components** (`scripts/components`)
- `block-inserter.mdx` — `BlockInserter`
- `link-section-editor.mdx` — `LinkSectionEditor`
- `file-picker.mdx` — `ManageFileButton` + `FileSelector`
- `media-picker.mdx` — `MediaPicker`
- `picker-placeholder.mdx` — `PickerPlaceholder`
- `server-side-render.mdx` — `ServerSideRender`
- `theme-options.mdx` — `ThemeOptionsPage`, `useThemeOptions`, `EsThemeOptionsContext`

**Helpers** (`scripts/helpers`)
- `breakpoints.mdx` — `getGlobalManifest`, `getBreakpointNames`, `getBreakpointData`, `getBreakpointUiData`, `getResponsiveData`
- `cookies.mdx` — full `cookies` object (`setCookie`, `getCookie`, expiration presets)
- `dynamic-import.mdx` — `dynamicImport`

### Changed

- `sidebars-components.js` — added a **Frontend libs Tailwind** category with **Components** and **Helpers** sub-categories registering every new page.

### Removed

- `fe-libs-components/introduction.mdx` — placeholder "Work in progress, coming soon!" page, replaced by the new `fe-libs-tailwind/getting-started.mdx`.

### Notes

- Pages use code examples and prop tables rather than live `<ComponentShowcase>` blocks, because most of these components depend on the WordPress block-editor runtime (`@wordpress/block-editor`, `@wordpress/data`, `MediaUpload`, `RichText`, store selectors) and can't render outside the editor.
- Each page links to the corresponding source file on GitHub via the standard `:::tip` block.

## QA Guide

1. Run the docs site locally (`bun start` in `website/`).
2. Open the **Components** sidebar.
3. Confirm the new **Frontend libs Tailwind** category appears below **Eightshift UI-Components**.
4. Click through each entry and verify:
   - The page renders without MDX errors.
   - The `:::tip [View source on GitHub →]` link points at the correct file in `infinum/eightshift-frontend-libs-tailwind`.
   - Code samples render with syntax highlighting and prop tables are formatted correctly.
5. Confirm cross-links work:
   - `getting-started` → each component/helper page.
   - `media-picker` → `file-picker#fileselector`.
   - `breakpoints` → `../es-ui-components/responsive`.
   - `picker-placeholder` → `./block-inserter`.

# Screenshots / Videos

<!-- Add screenshots of the new sidebar section and a sample page once the site is running locally. -->

# Productive ticket

No ticket.